### PR TITLE
feat (#312): Add idea sharing button

### DIFF
--- a/src/components/Idea/IdeaBubble/IdeaBubble.tsx
+++ b/src/components/Idea/IdeaBubble/IdeaBubble.tsx
@@ -10,6 +10,9 @@ import { useLocation, useParams } from 'react-router-dom';
 import LikeButton from '../../Buttons/LikeButton';
 import CategoryList from '../CategoryList';
 import UserBar from '../UserBar';
+import { successAlert } from '@/utils';
+import { useAppStore } from '@/store';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   idea: IdeaType;
@@ -23,6 +26,9 @@ interface Props {
 const IdeaBubble: React.FC<Props> = ({ children, idea, to, disabled = false, onDelete, onEdit }) => {
   const { idea_id } = useParams();
   const location = useLocation();
+  const [, dispatch] = useAppStore();
+  const { t } = useTranslation();
+
   return (
     <Stack width="100%" sx={{ scrollSnapAlign: 'center' }}>
       <ChatBubble disabled={disabled} comment={idea.approved < 0}>
@@ -63,6 +69,23 @@ const IdeaBubble: React.FC<Props> = ({ children, idea, to, disabled = false, onD
             link={`${location.pathname}/${to}`}
           >
             <Stack direction="row" alignItems="center">
+              {to && !disabled && (
+                <AppIconButton
+                  icon="link"
+                  onClick={() => {
+                    if (navigator.share) {
+                      navigator.share({
+                        title: idea.title,
+                        url: window.location.origin + to,
+                      });
+                    } else {
+                      navigator.clipboard.writeText(window.location.origin + to).then(() => {
+                        successAlert(t('clipboard.linkCopied'), dispatch);
+                      });
+                    }
+                  }}
+                />
+              )}
               <LikeButton disabled={disabled} item={idea} />
               {idea.sum_comments > 0 && !idea_id && (
                 <AppIconButton icon="chat" to={to} disabled={disabled}>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -28,6 +28,10 @@
     "show": "Anzeigen",
     "unarchive": "Aus Archiv holen"
   },
+  "clipboard": {
+    "linkCopied": "Link in die Zwischenablage kopiert",
+    "linkCopyFailed": "Link konnte nicht in die Zwischenablage kopiert werden"
+  },
   "auth": {
     "forgotPassword": {
       "button": "Passwort zurücksetzen",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -28,6 +28,10 @@
     "show": "Show",
     "unarchive": "Unarchive"
   },
+  "clipboard": {
+    "linkCopied": "Link copied to clipboard",
+    "linkCopyFailed": "Failed to copy link to clipboard"
+  },
   "auth": {
     "forgotPassword": {
       "button": "Reset password",


### PR DESCRIPTION
Add a button to share Ideas. Triggers navigator.share on mobile, and navigator.clipboard on desktop

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)