### PR TITLE
fix: room creation with default phase durations

### DIFF
--- a/src/components/DataFields/PhaseDurationFields.tsx
+++ b/src/components/DataFields/PhaseDurationFields.tsx
@@ -32,8 +32,8 @@ const PhaseDurationFields: React.FC<Props> = ({
   const theme = useTheme();
   const { room_id } = useParams();
   const [defaultDurations, setDefaultDurations] = useState<{ phase_duration_1: number; phase_duration_3: number }>({
-    phase_duration_1: 14,
-    phase_duration_3: 14,
+    phase_duration_1: control._defaultValues.phase_duration_1,
+    phase_duration_3: control._defaultValues.phase_duration_3,
   });
 
   const [error, setError] = useState<string>();
@@ -51,6 +51,8 @@ const PhaseDurationFields: React.FC<Props> = ({
         fields.forEach((field) => {
           if (response.data && field.name in response.data) {
             updated[field.name] = response.data[field.name];
+            // Set the form value to ensure React Hook Form recognizes it as the default
+            setValue(field.name, response.data[field.name]);
           }
         });
         setDefaultDurations(updated);
@@ -61,6 +63,8 @@ const PhaseDurationFields: React.FC<Props> = ({
         fields.forEach((field, index) => {
           if (response.data.length > 0) {
             updated[field.name] = response.data[index];
+            // Set the form value to ensure React Hook Form recognizes it as the default
+            setValue(field.name, response.data[index]);
           }
         });
         setDefaultDurations(updated);
@@ -70,7 +74,7 @@ const PhaseDurationFields: React.FC<Props> = ({
 
   useEffect(() => {
     getDurations();
-  }, []);
+  }, [room, room_id]);
 
   return (
     <Stack>
@@ -108,7 +112,7 @@ const PhaseDurationFields: React.FC<Props> = ({
             name={field.name}
             control={control}
             defaultValue={control._defaultValues[field.name] || defaultDurations[field.name]}
-            render={({ field, fieldState }) => {
+            render={({ field: fieldProps, fieldState }) => {
               if (!!fieldState.error) setError(fieldState.error.message);
               return (
                 <FormControl sx={{ flex: 1, minWidth: 'min(150px, 100%)' }}>
@@ -119,7 +123,8 @@ const PhaseDurationFields: React.FC<Props> = ({
                     variant="standard"
                     required={required}
                     disabled={disabled}
-                    {...field}
+                    {...fieldProps}
+                    value={fieldProps.value || defaultDurations[field.name]}
                     error={!!fieldState.error}
                     {...restOfProps}
                     slotProps={{

--- a/src/components/DataForms/RoomForms.tsx
+++ b/src/components/DataForms/RoomForms.tsx
@@ -19,6 +19,8 @@ import UsersField from '../DataFields/UsersField';
  * @component
  */
 
+const DEFAULT_PHASE_DURATION = 14; // Default duration in days
+
 interface RoomFormsProps {
   isDefault?: boolean;
   onClose: () => void;
@@ -48,7 +50,14 @@ const RoomForms: React.FC<RoomFormsProps> = ({ defaultValues, isDefault = false,
     formState: { errors },
   } = useForm({
     resolver: yupResolver(schema),
-    defaultValues: { room_name: defaultValues ? ' ' : '' },
+    defaultValues: {
+      room_name: defaultValues ? ' ' : '',
+      phase_duration_1: defaultValues?.phase_duration_1 || DEFAULT_PHASE_DURATION,
+      phase_duration_3: defaultValues?.phase_duration_3 || DEFAULT_PHASE_DURATION,
+      description_public: defaultValues?.description_public || '',
+      description_internal: defaultValues?.description_internal || null,
+      status: defaultValues?.status,
+    },
   });
 
   // Infer TypeScript type from the Yup schema


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Creation of new rooms with default durations where returning a 'not nullable' error. this is fixed now

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
