### PR TITLE
Announcement button missing text

### DIFF
--- a/src/components/DataFields/ConsentFiled.tsx
+++ b/src/components/DataFields/ConsentFiled.tsx
@@ -38,7 +38,7 @@ const ConsentField: React.FC<Props> = ({ control, sx }) => {
             <Controller
               name="consent_text"
               control={control}
-              defaultValue={t('actions.agree')}
+              defaultValue={control._defaultValues.consent_text}
               render={({ field, fieldState }) => (
                 <TextField
                   label={t('settings.columns.consent_text')}

--- a/src/components/DataForms/AnnouncementForms.tsx
+++ b/src/components/DataForms/AnnouncementForms.tsx
@@ -29,7 +29,7 @@ const AnnouncementForms: React.FC<AnnouncementFormsProps> = ({ defaultValues, on
     headline: yup.string().required(t('forms.validation.required')),
     body: yup.string().required(t('forms.validation.required')),
     user_needs_to_consent: yup.number(),
-    consent_text: yup.string(),
+    consent_text: yup.string().required(t('forms.validation.required')),
     status: yup.number(),
     target_group: yup.number(),
     target_id: yup.number(),
@@ -43,7 +43,13 @@ const AnnouncementForms: React.FC<AnnouncementFormsProps> = ({ defaultValues, on
     formState: { errors },
   } = useForm({
     resolver: yupResolver(schema),
-    defaultValues: { headline: defaultValues ? ' ' : '', user_needs_to_consent: 1 },
+    defaultValues: {
+      headline: defaultValues?.headline || '',
+      body: defaultValues?.body || '',
+      user_needs_to_consent: 1,
+      consent_text: t('actions.agree'),
+      status: defaultValues?.status || 1,
+    },
   });
 
   // Infer TypeScript type from the Yup schema

--- a/src/views/AskConsent/AskConsentView.tsx
+++ b/src/views/AskConsent/AskConsentView.tsx
@@ -122,7 +122,7 @@ const AskConsent = () => {
                   )}
                   {text.user_needs_to_consent > 0 && (
                     <Button variant="contained" onClick={() => consent(text.id)}>
-                      {text.consent_text || t('actions.agree')}
+                      {text.consent_text ?? t('actions.agree')}
                     </Button>
                   )}
                 </DialogActions>

--- a/src/views/AskConsent/AskConsentView.tsx
+++ b/src/views/AskConsent/AskConsentView.tsx
@@ -122,7 +122,7 @@ const AskConsent = () => {
                   )}
                   {text.user_needs_to_consent > 0 && (
                     <Button variant="contained" onClick={() => consent(text.id)}>
-                      {text.consent_text}
+                      {text.consent_text || t('actions.agree')}
                     </Button>
                   )}
                 </DialogActions>


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Announcement confirm button was missing text in case of creation with the default 'Agree' text.

Corrected the bug and marked this field as required

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
