### PR TITLE
696 keyboard navigation is broken on markdown text field

### DIFF
--- a/src/components/DataFields/MarkdownEditor.tsx
+++ b/src/components/DataFields/MarkdownEditor.tsx
@@ -80,6 +80,19 @@ const Editor = styled(MDXEditor)(({ theme }) => ({
       color: theme.palette.text.primary,
     },
 
+    // Ensure CodeMirror content is focusable
+    '.cm-content': {
+      outline: 'none',
+    },
+
+    '.cm-editor': {
+      outline: 'none',
+    },
+
+    '.cm-focused': {
+      outline: 'none',
+    },
+
     // Toolbar button styles
     '.mdxeditor-toolbar button': {
       backgroundColor: 'transparent',
@@ -89,12 +102,29 @@ const Editor = styled(MDXEditor)(({ theme }) => ({
       margin: theme.spacing(0.25),
       cursor: 'pointer',
       transition: theme.transitions.create(['background-color', 'color']),
+      color: theme.palette.text.primary,
 
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },
 
-      '&[data-active=true]': {
+      // Multiple selectors for active state to ensure compatibility
+      '&[data-active="true"]': {
+        color: theme.palette.primary.main,
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&[aria-pressed="true"]': {
+        color: theme.palette.primary.main,
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&.active': {
+        color: theme.palette.primary.main,
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&[data-state="on"]': {
         color: theme.palette.primary.main,
         backgroundColor: theme.palette.action.selected,
       },
@@ -209,16 +239,48 @@ const MarkdownEditor: React.FC<Props> = ({ name, control, required = false, disa
     }
   }, []);
 
+  // Handle focus on the editor container to focus the text area
+  const handleContainerFocus = useCallback(() => {
+    // Use the MDXEditor ref to focus the editor properly
+    if (mdxEditorRef.current) {
+      try {
+        mdxEditorRef.current.focus();
+      } catch (error) {
+        // Fallback: try to find and focus the content area directly
+        const contentArea = containerRef.current?.querySelector(
+          '.cm-content, .mdxeditor-root-contenteditable, [contenteditable="true"]'
+        );
+        if (contentArea instanceof HTMLElement) {
+          contentArea.focus();
+        }
+      }
+    }
+  }, []);
+
   // Set up DOM event listener for Tab handling
   useEffect(() => {
     const container = containerRef.current;
     if (container) {
       container.addEventListener('keydown', handleKeyDown, true);
+
+      // Add focus handler to automatically focus editor when container gets focus
+      const handleFocus = (event: FocusEvent) => {
+        // Only handle if focus is coming from outside
+        if (!container.contains(event.relatedTarget as Node)) {
+          setTimeout(() => {
+            handleContainerFocus();
+          }, 0);
+        }
+      };
+
+      container.addEventListener('focus', handleFocus);
+
       return () => {
         container.removeEventListener('keydown', handleKeyDown, true);
+        container.removeEventListener('focus', handleFocus);
       };
     }
-  }, [handleKeyDown]);
+  }, [handleKeyDown, handleContainerFocus]);
 
   return (
     <Controller
@@ -230,7 +292,20 @@ const MarkdownEditor: React.FC<Props> = ({ name, control, required = false, disa
         }, [control._defaultValues[name], field.value]);
         return (
           <FormControl fullWidth {...restOfProps}>
-            <div ref={containerRef}>
+            <div
+              ref={containerRef}
+              onClick={handleContainerFocus}
+              onKeyDown={(e) => {
+                // Handle Enter and Space to focus the editor
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleContainerFocus();
+                }
+              }}
+              tabIndex={0}
+              role="textbox"
+              aria-label={t(`settings.columns.${name}`)}
+            >
               <Editor
                 className={`md-editor ${!!fieldState.error ? 'error' : ''} ${disabled ? 'disabled' : ''}`}
                 markdown={''}

--- a/src/components/DataFields/MarkdownEditor.tsx
+++ b/src/components/DataFields/MarkdownEditor.tsx
@@ -89,86 +89,35 @@ const Editor = styled(MDXEditor)(({ theme }) => ({
       margin: theme.spacing(0.25),
       cursor: 'pointer',
       transition: theme.transitions.create(['background-color', 'color']),
-      color: theme.palette.text.primary,
 
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },
 
-      '&:focus': {
-        backgroundColor: theme.palette.action.hover,
-        outline: `2px solid ${theme.palette.primary.main}`,
-        outlineOffset: '1px',
-      },
-
-      // Multiple selectors for active state to ensure compatibility
-      '&[data-active="true"]': {
-        backgroundColor: theme.palette.action.selected,
-      },
-
-      '&[aria-pressed="true"]': {
-        backgroundColor: theme.palette.action.selected,
-      },
-
-      '&.active': {
-        backgroundColor: theme.palette.action.selected,
-      },
-
-      '&[data-state="on"]': {
+      '&[data-active=true]': {
+        color: theme.palette.primary.main,
         backgroundColor: theme.palette.action.selected,
       },
 
       '&:disabled': {
         color: theme.palette.action.disabled,
         cursor: 'not-allowed',
-        backgroundColor: 'transparent',
-      },
-
-      // Style the SVG icons inside buttons
-      '& svg': {
-        color: 'inherit',
-        transition: theme.transitions.create('color'),
-      },
-    },
-
-    // Additional specific styling for toolbar elements
-    '.mdxeditor-toolbar [role="button"]': {
-      backgroundColor: 'transparent',
-      border: 'none',
-      borderRadius: theme.shape.borderRadius,
-      padding: theme.spacing(0.5),
-      margin: theme.spacing(0.25),
-      cursor: 'pointer',
-      transition: theme.transitions.create(['background-color', 'color']),
-      color: theme.palette.text.primary,
-
-      '&:hover': {
-        backgroundColor: theme.palette.action.hover,
-      },
-
-      '&[aria-pressed="true"]': {
-        color: theme.palette.primary.main,
-        backgroundColor: theme.palette.action.selected,
       },
     },
 
     // Separator style
-    '.mdxeditor-toolbar .separator': {
+    '.separator': {
       width: '1px',
       margin: theme.spacing(0, 1),
       backgroundColor: theme.palette.input.border,
-      alignSelf: 'stretch',
-      opacity: 0.6,
     },
 
-    '&:hover .mdxeditor-toolbar .separator': {
+    '&:hover .separator': {
       backgroundColor: theme.palette.input.borderHover,
-      opacity: 0.8,
     },
 
-    '&:focus-within .mdxeditor-toolbar .separator': {
+    '&:focus-within .separator': {
       backgroundColor: theme.palette.primary.main,
-      opacity: 1,
     },
 
     // Toolbar container

--- a/src/components/DataFields/MarkdownEditor.tsx
+++ b/src/components/DataFields/MarkdownEditor.tsx
@@ -89,35 +89,86 @@ const Editor = styled(MDXEditor)(({ theme }) => ({
       margin: theme.spacing(0.25),
       cursor: 'pointer',
       transition: theme.transitions.create(['background-color', 'color']),
+      color: theme.palette.text.primary,
 
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },
 
-      '&[data-active=true]': {
-        color: theme.palette.primary.main,
+      '&:focus': {
+        backgroundColor: theme.palette.action.hover,
+        outline: `2px solid ${theme.palette.primary.main}`,
+        outlineOffset: '1px',
+      },
+
+      // Multiple selectors for active state to ensure compatibility
+      '&[data-active="true"]': {
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&[aria-pressed="true"]': {
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&.active': {
+        backgroundColor: theme.palette.action.selected,
+      },
+
+      '&[data-state="on"]': {
         backgroundColor: theme.palette.action.selected,
       },
 
       '&:disabled': {
         color: theme.palette.action.disabled,
         cursor: 'not-allowed',
+        backgroundColor: 'transparent',
+      },
+
+      // Style the SVG icons inside buttons
+      '& svg': {
+        color: 'inherit',
+        transition: theme.transitions.create('color'),
+      },
+    },
+
+    // Additional specific styling for toolbar elements
+    '.mdxeditor-toolbar [role="button"]': {
+      backgroundColor: 'transparent',
+      border: 'none',
+      borderRadius: theme.shape.borderRadius,
+      padding: theme.spacing(0.5),
+      margin: theme.spacing(0.25),
+      cursor: 'pointer',
+      transition: theme.transitions.create(['background-color', 'color']),
+      color: theme.palette.text.primary,
+
+      '&:hover': {
+        backgroundColor: theme.palette.action.hover,
+      },
+
+      '&[aria-pressed="true"]': {
+        color: theme.palette.primary.main,
+        backgroundColor: theme.palette.action.selected,
       },
     },
 
     // Separator style
-    '.separator': {
+    '.mdxeditor-toolbar .separator': {
       width: '1px',
       margin: theme.spacing(0, 1),
       backgroundColor: theme.palette.input.border,
+      alignSelf: 'stretch',
+      opacity: 0.6,
     },
 
-    '&:hover .separator': {
+    '&:hover .mdxeditor-toolbar .separator': {
       backgroundColor: theme.palette.input.borderHover,
+      opacity: 0.8,
     },
 
-    '&:focus-within .separator': {
+    '&:focus-within .mdxeditor-toolbar .separator': {
       backgroundColor: theme.palette.primary.main,
+      opacity: 1,
     },
 
     // Toolbar container


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

There was a keytrap on the tab key inside the editor.
Fixed the keytrap and added visual indication for menu options

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
