### PR TITLE
fix: Hover on icons should show tooltip text

### DIFF
--- a/src/components/Buttons/DeleteButton/DeleteButton.tsx
+++ b/src/components/Buttons/DeleteButton/DeleteButton.tsx
@@ -44,6 +44,7 @@ const DeleteButton: React.FC<Props> = ({ scope, disabled = false, onDelete, isLo
       <AppIconButton
         ref={buttonRef}
         icon="delete"
+        title={t('tooltips.delete')}
         disabled={disabled || isLoading}
         aria-label={t('actions.delete', { var: t(`scopes.${scope}.name`) })}
         aria-expanded={isOpen}

--- a/src/components/Buttons/EditButton/EditButton.tsx
+++ b/src/components/Buttons/EditButton/EditButton.tsx
@@ -9,7 +9,7 @@ interface Props extends IconButtonProps {
 const EditButton: React.FC<Props> = ({ disabled = false, onEdit, ...restOfProps }) => {
   const { t } = useTranslation();
   return (
-    <AppIconButton icon="edit" disabled={disabled} aria-label={t('actions.edit')} {...restOfProps} onClick={onEdit} />
+    <AppIconButton icon="edit" title={t('tooltips.edit')} disabled={disabled} aria-label={t('actions.edit')} {...restOfProps} onClick={onEdit} />
   );
 };
 

--- a/src/components/Buttons/LikeButton/LikeButton.tsx
+++ b/src/components/Buttons/LikeButton/LikeButton.tsx
@@ -40,6 +40,7 @@ const LikeButton: React.FC<Props> = ({ item, disabled }) => {
   return (
     <AppIconButton
       icon={likeStatus ? 'heartFull' : 'heart'}
+      title={t(`tooltips.${likeStatus ? 'heartFull' : 'heart'}`)}
       onClick={toggleLike}
       disabled={disabled || !checkPermissions('ideas', 'like')}
       aria-label={likeStatus ? t('actions.unlike') : t('actions.like')}

--- a/src/components/Buttons/MessagesButton/MessagesButton.tsx
+++ b/src/components/Buttons/MessagesButton/MessagesButton.tsx
@@ -3,6 +3,7 @@ import { getPersonalMessages } from '@/services/messages';
 import { Badge, IconButtonProps, Skeleton } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import {t} from "i18next";
 
 const MessagesButton: React.FC<IconButtonProps> = ({ ...restOfProps }) => {
   const { pathname } = useLocation();
@@ -28,7 +29,7 @@ const MessagesButton: React.FC<IconButtonProps> = ({ ...restOfProps }) => {
         },
       }}
     >
-      <AppIconButton icon="message" to="/messages" {...restOfProps} />
+      <AppIconButton icon="message" title={t('tooltips.message')} to="/messages" {...restOfProps} />
     </Badge>
   ) : (
     <Skeleton variant="circular" sx={{ width: 20, aspectRatio: 1, mx: 1 }} />

--- a/src/components/Buttons/ReportButton/ReportButton.tsx
+++ b/src/components/Buttons/ReportButton/ReportButton.tsx
@@ -42,6 +42,7 @@ ${data.content || ''}
         data-testid="report-button"
         ref={buttonRef}
         icon="report"
+        title={t('tooltips.report')}
         disabled={disabled}
         aria-label={t('actions.contentReport')}
         aria-expanded={isOpen}

--- a/src/components/Buttons/UpdatesButton/UpdatesButton.tsx
+++ b/src/components/Buttons/UpdatesButton/UpdatesButton.tsx
@@ -3,6 +3,7 @@ import { getUpdates } from '@/services/dashboard';
 import { Badge, IconButtonProps, Skeleton } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import {t} from "i18next";
 
 const UpdatesButton: React.FC<IconButtonProps> = ({ ...restOfProps }) => {
   const { pathname } = useLocation();
@@ -30,10 +31,10 @@ const UpdatesButton: React.FC<IconButtonProps> = ({ ...restOfProps }) => {
           },
         }}
       >
-        <AppIconButton icon="heart" to="/updates" {...restOfProps} />
+        <AppIconButton icon="heart" title={t('tooltips.heart')} to="/updates" {...restOfProps} />
       </Badge>
     ) : (
-      <AppIconButton icon="heart" to="/updates" {...restOfProps} />
+      <AppIconButton icon="heart" title={t('tooltips.heart')} to="/updates" {...restOfProps} />
     )
   ) : (
     <Skeleton variant="circular" sx={{ width: 20, aspectRatio: 1, mx: 1 }} />

--- a/src/components/DataTable/DataItem.tsx
+++ b/src/components/DataTable/DataItem.tsx
@@ -134,6 +134,7 @@ const DataItem: React.FC<Props> = ({ row, column }) => {
             className="noPrint"
             size="small"
             icon={hidden ? 'visibilityOn' : 'visibilityOff'}
+            title={t(`tooltips.${hidden ? 'visibilityOn' : 'visibilityOff'}`)}
             onClick={(e) => {
               e.stopPropagation();
               setHidden(!hidden);

--- a/src/components/DelegateVote/DelegateVote.tsx
+++ b/src/components/DelegateVote/DelegateVote.tsx
@@ -155,7 +155,7 @@ const DelegateVote = ({ open, delegate, onClose, triggerRef }: Props) => {
               value={filter}
               fullWidth
               startAdornment={<AppIcon icon="search" size="small" sx={{ mr: 1 }} />}
-              endAdornment={<AppIconButton icon="close" size="small" onClick={() => setFilter('')} />}
+              endAdornment={<AppIconButton icon="close" title={t('tooltips.close')} size="small" onClick={() => setFilter('')} />}
               aria-label={t('actions.search')}
             />
             <Stack my={1} overflow="auto" role="listbox" aria-label={t('delegation.userList')}>

--- a/src/components/Idea/ApprovalCard/ApprovalCard.tsx
+++ b/src/components/Idea/ApprovalCard/ApprovalCard.tsx
@@ -119,7 +119,7 @@ const ApprovalCard = ({ idea, disabled = false, onReload }: ApprovalCardProps) =
               </Typography>
             </Stack>
             {checkPermissions('ideas', 'approve') && (
-              <AppIconButton icon="edit" onClick={() => setEditing(true)} sx={{ m: -1 }} />
+              <AppIconButton icon="edit" title={t('tooltips.edit')} onClick={() => setEditing(true)} sx={{ m: -1 }} />
             )}
           </Stack>
         )}

--- a/src/components/Idea/IdeaBubble/IdeaBubble.tsx
+++ b/src/components/Idea/IdeaBubble/IdeaBubble.tsx
@@ -73,6 +73,7 @@ const IdeaBubble: React.FC<Props> = ({ children, idea, to, disabled = false, onD
               {to && !disabled && (
                 <AppIconButton
                   icon="link"
+                  title={t('tooltips.link')}
                   onClick={() => {
                     if (navigator.share) {
                       navigator.share({
@@ -89,7 +90,7 @@ const IdeaBubble: React.FC<Props> = ({ children, idea, to, disabled = false, onD
               )}
               <LikeButton disabled={disabled} item={idea} />
               {idea.sum_comments > 0 && !idea_id && (
-                <AppIconButton icon="chat" to={to} disabled={disabled}>
+                <AppIconButton icon="chat" title={t('tooltips.chat')} to={to} disabled={disabled}>
                   {idea.sum_comments}
                 </AppIconButton>
               )}

--- a/src/components/ImageEditor/ImageEditor.tsx
+++ b/src/components/ImageEditor/ImageEditor.tsx
@@ -224,9 +224,9 @@ const ImageEditor: React.FC<Props> = ({ id, width = 200, height = 200, rounded =
                 justifyContent="center"
                 sx={{ mt: 2, display: 'flex', gap: 2, justifyContent: 'center' }}
               >
-                <AppIconButton icon="zoomOut" onClick={() => handleZoom(-0.1)} />
-                <AppIconButton icon="cancel" onClick={handleReset} />
-                <AppIconButton icon="zoomIn" onClick={() => handleZoom(0.1)} />
+                <AppIconButton icon="zoomOut" title={t('tooltips.zoomOut')} onClick={() => handleZoom(-0.1)} />
+                <AppIconButton icon="cancel" title={t('tooltips.cancel')} onClick={handleReset} />
+                <AppIconButton icon="zoomIn" title={t('tooltips.zoomIn')} onClick={() => handleZoom(0.1)} />
               </Stack>
             </Box>
           )}

--- a/src/components/MoreOptions/MoreOptions.tsx
+++ b/src/components/MoreOptions/MoreOptions.tsx
@@ -83,6 +83,7 @@ const MoreOptions: React.FC<Props> = ({ item, scope, children, onDelete, onEdit,
         </Collapse>
         <AppIconButton
           icon={open ? 'close' : 'more'}
+          title={t(`tooltips.${open ? 'close' : 'more'}`)}
           onClick={toggleOptions}
           aria-expanded={open}
           aria-label={open ? t('actions.close') : t('actions.more')}

--- a/src/components/ProfileEditor/RestrictedField.tsx
+++ b/src/components/ProfileEditor/RestrictedField.tsx
@@ -41,6 +41,7 @@ const RestrictedField = ({ name, control, ...restOfProps }: Props) => {
                   <AppIconButton
                     size="small"
                     icon={disabled ? 'lockOpen' : 'lockClosed'}
+                    title={t(`actions.${disabled ? 'edit' : 'lock'}`)}
                     aria-label={disabled ? t('actions.edit') : t('actions.lock')}
                     aria-pressed={!disabled}
                     sx={{ mr: -1.5 }}

--- a/src/components/ReportCard/ReportCard.tsx
+++ b/src/components/ReportCard/ReportCard.tsx
@@ -184,7 +184,7 @@ ${message}`,
     <Card variant="outlined" sx={{ borderRadius: 5, overflow: 'visible' }} {...restOfProps}>
       <CardHeader
         title={report.headline}
-        action={<AppIconButton icon={report.status === 1 ? 'archive' : 'unarchive'} onClick={toggleArchive} />}
+        action={<AppIconButton icon={report.status === 1 ? 'archive' : 'unarchive'} title={t(`tooltips.${report.status === 1 ? 'archive' : 'unarchive'}`)} onClick={toggleArchive} />}
       />
       <Divider />
       <CardContent sx={{ bgcolor: blueGrey[50] }}>

--- a/src/layout/SideBar/SideBar.tsx
+++ b/src/layout/SideBar/SideBar.tsx
@@ -98,7 +98,7 @@ const SideBar = ({ anchor, open, variant, onClose, ...restOfProps }: DrawerSideB
         aria-label={t('ui.accessibility.sidebarActions')}
       >
         <BugButton target={location.pathname} />
-        <AppIconButton onClick={window.print} icon="print" title={t('actions.print')} aria-label={t('actions.print')} />
+        <AppIconButton onClick={window.print} icon="print"  title={t('actions.print')} aria-label={t('actions.print')} />
         <AppIconButton
           onClick={onSwitchDarkMode}
           icon={state.darkMode ? 'day' : 'night'}

--- a/src/layout/TopBar/TopBar.tsx
+++ b/src/layout/TopBar/TopBar.tsx
@@ -83,7 +83,7 @@ const TopBar: React.FC = () => {
           {location[1] === '' ? (
             <img src={`${import.meta.env.VITE_APP_BASENAME}img/Aula_Icon.svg`} alt={t('app.name.icon')} />
           ) : (
-            <AppIconButton icon="back" onClick={() => goto(getReturnPath())} />
+            <AppIconButton icon="back" title={t('tooltips.back')} onClick={() => goto(getReturnPath())} />
           )}
         </Box>
         {/* Navigation Breadcrumbs */}
@@ -127,13 +127,13 @@ const TopBar: React.FC = () => {
         {checkPermissions('system', 'hide') ? (
           <Stack direction="row">
             <LocaleSwitch />
-            <AppIconButton icon="logout" onClick={onLogout} />
+            <AppIconButton icon="logout" title={t('tooltips.logout')} onClick={onLogout} />
           </Stack>
         ) : (
           <Stack direction="row" spacing={0.5} sx={{ ml: 'auto' }}>
             <MessagesButton />
             <UpdatesButton />
-            <AppIconButton icon="menu" onClick={menuToggle} sx={{ display: { xs: 'block', md: 'none' } }} />
+            <AppIconButton icon="menu" title={t('tooltips.menu')} onClick={menuToggle} sx={{ display: { xs: 'block', md: 'none' } }} />
           </Stack>
         )}
         <SideBar

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -528,13 +528,32 @@
   },
   "tooltips": {
     "approval": "Das Prüfungsteam überprüft Ideen auf Machbarkeit vor der Abstimmung",
+    "archive": "Archivieren",
+    "back": "Zurück",
+    "cancel": "Abbrechen",
+    "chat": "Chat öffnen",
+    "close": "Schließen",
     "comment": "Kommentare helfen, Ideen durch konstruktives Feedback zu verbessern",
     "delegate": "Du kannst deine Stimme an eine andere Person übertragen und sie jederzeit zurücknehmen",
+    "delete": "Löschen",
     "discussion": "Hier werden Ideen durch Zusammenarbeit in Projektpläne verwandelt",
+    "edit": "Bearbeiten",
+    "heart": "Gefällt mir",
+    "heartFull": "Gefällt mir nicht mehr",
+    "link": "Link kopieren",
+    "logout": "Abmelden",
+    "menu": "Menü",
+    "message": "Nachricht senden",
+    "more": "Mehr",
+    "print": "Drucken",
     "quorum": "Erforderliche Likes, um in die Diskussionsphase zu gelangen",
+    "report": "Melden",
     "results": "Abstimmungsergebnisse und genehmigte Ideen zur Umsetzung anzeigen",
+    "unarchive": "Wiederherstellen",
     "voting": "Stimme für genehmigte Ideen abgeben",
-    "wild": "Hier kannst du erste Ideen und Vorschläge posten"
+    "wild": "Hier kannst du erste Ideen und Vorschläge posten",
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern"
   },
   "user": {
     "avatar": "Benutzeravatar für {{id}}"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -528,13 +528,32 @@
   },
   "tooltips": {
     "approval": "The approval team reviews ideas for feasibility before voting",
+    "archive": "Archive",
+    "back": "Go back",
+    "cancel": "Cancel",
+    "chat": "Open chat",
+    "close": "Close",
     "comment": "Comments help improve ideas through constructive feedback",
     "delegate": "You can delegate your vote to another person and revoke it at any time",
+    "delete": "Delete",
     "discussion": "Ideas are refined into project plans through collaboration",
+    "edit": "Edit",
+    "heart": "Like",
+    "heartFull": "Unlike",
+    "link": "Copy Link",
+    "logout": "Log out",
+    "menu": "Menu",
+    "message": "Send a message",
+    "more": "More",
+    "print": "Print",
     "quorum": "Required likes to advance to discussion phase",
+    "report": "Report",
     "results": "View voting results and approved ideas for implementation",
+    "unarchive": "Unarchive",
     "voting": "Cast your vote on approved ideas",
-    "wild": "Share and like initial ideas and suggestions"
+    "wild": "Share and like initial ideas and suggestions",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out"
   },
   "user": {
     "avatar": "User avatar for {{id}}"

--- a/src/views/Messages/Announcement/AnnouncementView.tsx
+++ b/src/views/Messages/Announcement/AnnouncementView.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {t} from "i18next";
 
 /**
  * Renders "Announcement" view
@@ -96,7 +97,7 @@ const AnnouncementView = () => {
           <CardHeader
             title={announcement.headline}
             action={
-              <AppIconButton icon={announcement.status === 1 ? 'archive' : 'unarchive'} onClick={toggleArchive} />
+              <AppIconButton icon={announcement.status === 1 ? 'archive' : 'unarchive'} title={t(`tooltips.${announcement.status === 1 ? 'archive' : 'unarchive'}`)} onClick={toggleArchive} />
             }
           />
           <CardContent>

--- a/src/views/Messages/Message/MessageView.tsx
+++ b/src/views/Messages/Message/MessageView.tsx
@@ -5,6 +5,7 @@ import { Card, CardActions, CardContent, CardHeader, Divider, Skeleton, Stack, T
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import {t} from "i18next";
 
 /**
  * Renders "Message" view
@@ -75,7 +76,7 @@ const MessageView = () => {
         <Card variant="outlined">
           <CardHeader
             title={message.headline}
-            action={<AppIconButton icon={message.status === 1 ? 'archive' : 'unarchive'} onClick={toggleArchive} />}
+            action={<AppIconButton icon={message.status === 1 ? 'archive' : 'unarchive'} title={t(`tooltips.${message.status === 1 ? 'archive' : 'unarchive'}`)} onClick={toggleArchive} />}
           />
           <CardContent>
             <Typography py={2}>{message.body}</Typography>

--- a/src/views/Messages/UserMessagesView.tsx
+++ b/src/views/Messages/UserMessagesView.tsx
@@ -69,7 +69,7 @@ const UserMessagesView = () => {
                 <Typography flex={1} px={2}>
                   {message.headline}
                 </Typography>
-                <AppIconButton size="small" icon="close" />
+                <AppIconButton size="small" icon="close" title={t('tooltips.close')} />
               </Stack>
             );
           })}

--- a/src/views/Settings/Config/TimedCommands/TimedCommands.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommands.tsx
@@ -84,7 +84,7 @@ const TimedCommands = () => {
                       <TableCell>{command.parameters}</TableCell>
                       <TableCell>{command.date_start}</TableCell>
                       <TableCell align="right">
-                        <AppIconButton icon="delete" onClick={() => setDeleteId(command.id)} />
+                        <AppIconButton icon="delete" title={t('tooltips.delete')} onClick={() => setDeleteId(command.id)} />
                       </TableCell>
                     </TableRow>
                   );


### PR DESCRIPTION
## Context 
Issue #674 
Some icon buttons in the application had no text labels or tooltips, making it hard for users to understand their purpose, especially for less obvious icons like "copy link". This PR adds descriptive tooltips to improve accessibility and clarity for all users.

Since I only had access to the login page during development, I tested the tooltip rendering there. The translation files (en.json and de.json) were also updated to include the new tooltip texts.


## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
