### PR TITLE
fix: pull/edit avatar from instance's folder

### DIFF
--- a/src/components/ImageEditor/ImageEditor.tsx
+++ b/src/components/ImageEditor/ImageEditor.tsx
@@ -20,6 +20,7 @@ interface Props {
 const ImageEditor: React.FC<Props> = ({ id, width = 200, height = 200, rounded = false, isOpen, onClose }) => {
   const { t } = useTranslation();
   const api_url = localStorageGet('api_url');
+  const code = localStorageGet('code');
 
   const [image, setImage] = useState<string | null>(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -44,7 +45,7 @@ const ImageEditor: React.FC<Props> = ({ id, width = 200, height = 200, rounded =
 
   const downloadUserAvatar = async () => {
     const response = await getAvatar(id);
-    if (response.data && response.data.length > 0) setImage(`${api_url}/files/${response.data[0].filename}`);
+    if (response.data && response.data.length > 0) setImage(`${api_url}/files/${code}/${response.data[0].filename}`);
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -17,6 +17,7 @@ interface Props extends AvatarProps {
 const UserAvatar = ({ id, size = 32, sx, ...restOfProps }: Props) => {
   const { t } = useTranslation();
   const api_url = localStorageGet('api_url');
+  const code = localStorageGet('code');
   const [userAvatar, setUserAvatar] = useState<string>('');
   const downloadUserAvatar = async () => {
     const response = await getAvatar(id);
@@ -37,7 +38,7 @@ const UserAvatar = ({ id, size = 32, sx, ...restOfProps }: Props) => {
         ...sx,
       }}
       alt={t('user.avatar', { id: id })}
-      src={`${api_url}/files/${userAvatar}` || ''}
+      src={`${api_url}/files/${code}/${userAvatar}` || ''}
       {...restOfProps}
     >
       {!userAvatar && <AppIcon icon="avatar" />}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
