### PR TITLE
Continue event propagation when Enter or Space is pressed on Markdown editor

### DIFF
--- a/src/components/DataFields/MarkdownEditor.tsx
+++ b/src/components/DataFields/MarkdownEditor.tsx
@@ -298,9 +298,8 @@ const MarkdownEditor: React.FC<Props> = ({ name, control, required = false, disa
               onKeyDown={(e) => {
                 // Handle Enter and Space to focus the editor
                 if (e.key === 'Enter' || e.key === ' ') {
-                  // TODO: Why???
                   //e.preventDefault();
-                  handleContainerFocus();
+                  // handleContainerFocus();
                 }
               }}
               tabIndex={0}

--- a/src/components/DataFields/MarkdownEditor.tsx
+++ b/src/components/DataFields/MarkdownEditor.tsx
@@ -298,7 +298,8 @@ const MarkdownEditor: React.FC<Props> = ({ name, control, required = false, disa
               onKeyDown={(e) => {
                 // Handle Enter and Space to focus the editor
                 if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
+                  // TODO: Why???
+                  //e.preventDefault();
                   handleContainerFocus();
                 }
               }}


### PR DESCRIPTION


## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
