### PR TITLE
fix: updated English date format to DD MMMM YYYY

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -136,7 +136,7 @@ Returns an object with the following methods:
 
 **Locale Support:**
 
-- **English (en)**: MM/DD/YYYY hh:mm:ss A (US format with AM/PM)
+- **English (en)**: DD MMMM YYYY HH:mm:ss (e.g. 27 June 2025 14:30:00)
 - **German (de)**: DD.MM.YYYY HH:mm:ss (German format with 24-hour time)
 - **Default**: YYYY-MM-DD HH:mm:ss (ISO format)
 
@@ -162,7 +162,7 @@ function EventCard({ event }) {
 
 | Language     | Input: 2025-06-27T14:30:00Z | DateTime Output        | Date Only Output |
 | ------------ | --------------------------- | ---------------------- | ---------------- |
-| English (en) | 2025-06-27T14:30:00Z        | 06/27/2025 02:30:00 PM | 06/27/2025       |
+| English (en) | 2025-06-27T14:30:00Z        | 27 June 2025 14:30:00  | 27 June 2025     |
 | German (de)  | 2025-06-27T14:30:00Z        | 27.06.2025 14:30:00    | 27.06.2025       |
 | Default      | 2025-06-27T14:30:00Z        | 2025-06-27 14:30:00    | 2025-06-27       |
 

--- a/docs/UTILS.md
+++ b/docs/UTILS.md
@@ -71,7 +71,7 @@ For formatting with explicit language control:
 
 | Language     | DateTime Input       | DateTime Output        | Date Only Output |
 | ------------ | -------------------- | ---------------------- | ---------------- |
-| English (en) | 2025-06-27T14:30:00Z | 06/27/2025 02:30:00 PM | 06/27/2025       |
+| English (en) | 2025-06-27T14:30:00Z | 27 June 2025 14:30:00  | 27 June 2025     |
 | German (de)  | 2025-06-27T14:30:00Z | 27.06.2025 14:30:00    | 27.06.2025       |
 | Default      | 2025-06-27T14:30:00Z | 2025-06-27 14:30:00    | 2025-06-27       |
 

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -7,8 +7,8 @@ export const DEFAULT_FORMAT_DATE_ONLY = 'YYYY-MM-DD';
 // Locale-specific date formats
 export const DATE_FORMATS = {
   en: {
-    dateTime: 'MM/DD/YYYY hh:mm:ss A', // US format with AM/PM
-    dateOnly: 'MM/DD/YYYY',
+    dateTime: 'DD MMMM YYYY HH:mm:ss',  // 01 June 2025 14:30:00
+    dateOnly: 'DD MMMM YYYY',           // 01 June 2025
   },
   de: {
     dateTime: 'DD.MM.YYYY HH:mm:ss', // German format


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fixed for the desired formatting for english date and dateTime.
Updated documentation.

format en: DD MMMM YYYY

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)

Issue #673 