### PR TITLE
fix: public-config overwrite on deploy

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -20,5 +20,5 @@ jobs:
         run: |
           npm i
           npm run build-${{ github.ref_name }}
-          cp -vr build/* /var/www-aula-${{ github.ref_name }}/
+          rsync -av --delete --exclude public-config.json build/ /var/www-aula-${{ github.ref_name }}
         shell: bash


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

The problem is i deliberately made public-config.json owned by root:root because i manually edited it, because i introduced a bug with the Dockerization of FE..

the bug is that public-config.json has placeholders that docker-entrypoint.sh is supposed to inject but until we move to running FE from Docker this is not happening.. 

This PR makes sure that we don't overwrite the public-config.json as a temporary fix until we migrate to running everything with Docker.

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
