### PR TITLE
fix: use github commit sha - short version - when releasing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  IMAGE_TAG_SHA: 'aulaapp/aula-frontend:${{ github.sha }}'
+  IMAGE_TAG_SHA: 'aulaapp/aula-frontend:${GITHUB_SHA::7}'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  IMAGE_TAG_SHA: 'aulaapp/aula-frontend:${{ github.sha }}'
+  IMAGE_TAG_SHA: 'aulaapp/aula-frontend:${GITHUB_SHA::7}'
   IMAGE_TAG_LATEST: 'aulaapp/aula-frontend:latest'
   IMAGE_TAG_VERSION: 'aulaapp/aula-frontend:${{ github.event.release.tag_name }}'
 


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->
small fix for using short version of git sha as docker image tag
