### PR TITLE
feat: add frontend filtering to comments

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -302,7 +302,10 @@
     },
     "comments": {
       "name": "Verbesserungsvorschlag",
-      "plural": "Verbesserungsvorschläge"
+      "plural": "Verbesserungsvorschläge",
+      "search": {
+        "placeholder": "Kommentare durchsuchen..."
+      }
     },
     "groups": {
       "name": "Gruppe",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -302,7 +302,10 @@
     },
     "comments": {
       "name": "Comment",
-      "plural": "Comments"
+      "plural": "Comments",
+      "search": {
+        "placeholder": "Search comments..."
+      }
     },
     "groups": {
       "name": "Group",

--- a/src/views/Comment/CommentView.tsx
+++ b/src/views/Comment/CommentView.tsx
@@ -1,14 +1,13 @@
-import { AppIcon } from '@/components';
-import SortButton from '@/components/Buttons/SortButton';
+import { AppIcon, ScopeHeader } from '@/components';
 import { CommentForms } from '@/components/DataForms';
 import CommentBubble from '@/components/Idea/CommentBubble';
 import IdeaBubbleSkeleton from '@/components/Idea/IdeaBubble/IdeaBubbleSkeleton';
-import KnowMore from '@/components/KnowMore';
+import { useSearchAndSort, createTextFilter, useFilter } from '@/hooks';
 import { deleteComment, getCommentsByIdea } from '@/services/comments';
 import { CommentType } from '@/types/Scopes';
 import { checkPermissions } from '@/utils';
-import { Drawer, Fab, Stack, Typography } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { Drawer, Fab, Stack } from '@mui/material';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
@@ -27,18 +26,32 @@ const Comments = () => {
   const { t } = useTranslation();
   const { idea_id, phase } = useParams<RouteParams>();
 
-  const COMMENT_SORT_OPTIONS = [
-    { label: t('settings.columns.created'), value: 'created' },
-    { label: t('settings.columns.sum_likes'), value: 'sum_likes' },
-  ] as Array<{ label: string; value: keyof CommentType }>;
+  // Manage search and sort state for comments
+  const { searchQuery, sortKey, sortDirection, scopeHeaderProps } = useSearchAndSort({
+    sortOptions: [
+      { value: 'created', labelKey: 'settings.columns.created' },
+      { value: 'sum_likes', labelKey: 'settings.columns.sum_likes' },
+      { value: 'displayname', labelKey: 'settings.columns.displayname' },
+    ],
+  });
 
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [comments, setComments] = useState<CommentType[]>([]);
-  const [edit, setEdit] = useState<CommentType | boolean>(false); // false = update dialog closed ;true = new idea; CommentFormData = edit idea;
+  const [edit, setEdit] = useState<CommentType | boolean>(false);
 
-  const [orderby, setOrderby] = useState<keyof CommentType>(COMMENT_SORT_OPTIONS[0].value);
-  const [asc, setAsc] = useState(false);
+  // Create filter function for comments (searches in content and displayname)
+  const commentFilterFunction = useMemo(
+    () => createTextFilter<CommentType>(['content', 'displayname']),
+    []
+  );
+
+  // Apply filtering to comments
+  const filteredComments = useFilter({
+    data: comments,
+    filterValue: searchQuery,
+    filterFunction: commentFilterFunction,
+  });
 
   const fetchComments = useCallback(async () => {
     if (!idea_id) return;
@@ -63,53 +76,43 @@ const Comments = () => {
     fetchComments();
   };
 
+  // Sort the filtered comments
+  const sortedComments = useMemo(() => {
+    return filteredComments.slice().sort((a, b) => {
+      const valueA = a[sortKey as keyof CommentType];
+      const valueB = b[sortKey as keyof CommentType];
+      
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return sortDirection === 'asc' ? valueA - valueB : valueB - valueA;
+      }
+      
+      const comparison = String(valueA).localeCompare(String(valueB));
+      return sortDirection === 'asc' ? comparison : -comparison;
+    });
+  }, [filteredComments, sortKey, sortDirection]);
+
   return (
     <Stack alignItems="center" width="100%" spacing={2} pt={2}>
       {isLoading ? (
         <IdeaBubbleSkeleton />
       ) : comments.length > 0 ? (
         <>
-          <Stack direction="row" justifyContent="space-between" pl={1} width="100%">
-            <KnowMore title={t('tooltips.comment')}>
-              <Stack direction="row" alignItems="center" gap={1}>
-                <AppIcon icon="comment" />
-                <Typography variant="h3">
-                  {String(comments.length)} {t('scopes.comments.plural')}
-                </Typography>
-              </Stack>
-            </KnowMore>
-            <SortButton
-              options={COMMENT_SORT_OPTIONS}
-              onSelect={(orderby: string) => {
-                setOrderby(orderby as keyof CommentType);
-              }}
-              onReorder={(asc: boolean) => {
-                setAsc(asc);
-              }}
-            />
-          </Stack>
+          <ScopeHeader
+            title={t('scopes.comments.plural')}
+            scopeKey="comments"
+            totalCount={comments.length}
+            {...scopeHeaderProps}
+          />
           <Stack width="100%" gap={2}>
-            {comments
-              .slice()
-              .sort((a, b) => {
-                const valueA = a[orderby];
-                const valueB = b[orderby];
-                if (typeof valueA === 'number' && typeof valueB === 'number') {
-                  return asc ? valueA - valueB : valueB - valueA;
-                }
-                return asc
-                  ? String(valueA).localeCompare(String(valueB))
-                  : String(valueB).localeCompare(String(valueA));
-              })
-              .map((comment) => (
-                <CommentBubble
-                  key={comment.id}
-                  comment={comment}
-                  onEdit={() => setEdit(comment)}
-                  onDelete={() => onDelete(comment.id)}
-                  disabled={Number(phase) >= 20}
-                />
-              ))}
+            {sortedComments.map((comment) => (
+              <CommentBubble
+                key={comment.id}
+                comment={comment}
+                onEdit={() => setEdit(comment)}
+                onDelete={() => onDelete(comment.id)}
+                disabled={Number(phase) >= 20}
+              />
+            ))}
           </Stack>
         </>
       ) : null}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

comments were being filtered on backend, leading to slow response and error prone behaviour. It was moved to front end

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
