### PR TITLE
fix(csv): invoke addAllCSV on BE API for importing to multiple Rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Bug fixes:**
   - Display time considering correct local timezones
+  - Importing CSV to multiple Rooms works correctly resolving duplicated Users
 
 ## 1.4.1
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -86,13 +86,13 @@ async function setAllowRegistration(status: boolean): Promise<DefaultSettingsRes
   return response as DefaultSettingsResponse;
 }
 
-export async function addCSV(csv: string, room_id: string, user_level: RoleTypes): Promise<GenericResponse> {
+export async function addAllCSV(csv: string, room_ids: Array<string>, user_level: RoleTypes): Promise<GenericResponse> {
   const response = await databaseRequest({
     model: 'User',
-    method: 'addCSV',
+    method: 'addAllCSV',
     arguments: {
       csv,
-      room_id,
+      room_ids,
       user_level,
     },
   });

--- a/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
+++ b/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
@@ -1,7 +1,7 @@
 import { AppIcon } from '@/components';
 import RoomField from '@/components/DataFields/RoomField';
 import SelectRole from '@/components/SelectRole';
-import { addCSV } from '@/services/config';
+import { addAllCSV } from '@/services/config';
 import { useAppStore } from '@/store';
 import { RoleTypes, UpdateType } from '@/types/SettingsTypes';
 import {
@@ -95,14 +95,12 @@ const DataSettings = ({ onReload }: Props) => {
 
   const uploadCSV = async (csv: string) => {
     setLoading(true);
-    const responses = await Promise.all(rooms.add.map((room) => addCSV(csv, room, role)));
+    const response = await addAllCSV(csv, rooms.add, role);
     setLoading(false);
-    responses.forEach((response) => {
-      if (!response.data) {
-        dispatch({ type: 'ADD_POPUP', message: { message: t('errors.default'), type: 'error' } });
-        return;
-      }
-    });
+    if (!response.data) {
+      dispatch({ type: 'ADD_POPUP', message: { message: t('errors.default'), type: 'error' } });
+      return;
+    }
     dispatch({ type: 'ADD_POPUP', message: { message: t('forms.csv.success'), type: 'success' } });
     onReload();
     onReset();

--- a/tests/mutating/main/categories.spec.ts
+++ b/tests/mutating/main/categories.spec.ts
@@ -43,7 +43,7 @@ test.describe('Categories flow', () => {
     const admin = await browsers.newPage(browsers.admins_browser);
     const host = shared.getHost();
 
-    await admin.goto(host || 'http://localhost:3000');
+    await admin.goto(host);
 
     data.categoryName = 'TESTING' + shared.gensym();
 

--- a/tests/mutating/main/instance_offline_mode.spec.ts
+++ b/tests/mutating/main/instance_offline_mode.spec.ts
@@ -44,7 +44,7 @@ test.describe('Instance Offline Mode', () => {
     const userContext = await userBrowser.newContext();
     const user = await userContext.newPage();
 
-    // User tries to login and should be redirected to error page
+    // User tries to login
     await user.goto(host);
     await user.fill('input[name="username"]', fixtures.alice.username);
     await user.fill('input[name="password"]', fixtures.alice.password);

--- a/tests/mutating/main/reporting.spec.ts
+++ b/tests/mutating/main/reporting.spec.ts
@@ -1,11 +1,8 @@
-import { test, expect, BrowserContext, Page, chromium, Browser } from '@playwright/test';
-import { sleep } from '../../shared/utils';
+import { test, expect } from '@playwright/test';
 import * as shared from '../../shared/shared';
-import * as users from '../../shared/page_interactions/users';
 import * as rooms from '../../shared/page_interactions/rooms';
 import * as ideas from '../../shared/page_interactions/ideas';
 import * as ui from '../../shared/page_interactions/interface';
-import * as boxes from '../../shared/page_interactions/boxes';
 
 import * as fixtures from '../../fixtures/users';
 import * as browsers from '../../shared/page_interactions/browsers';

--- a/tests/mutating/main/users_csv_and_delete.spec.ts
+++ b/tests/mutating/main/users_csv_and_delete.spec.ts
@@ -84,6 +84,8 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     await expect(ApproveButton).toBeVisible();
     await ApproveButton.click({ timeout: 1000 });
 
+    // @TODO: nikola - capture HTTP traffic and assert Response is 200 OK, not 409
+
     fs.unlinkSync(filePath);
 
     // verify user is added
@@ -164,9 +166,7 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     await SecondApproveButton2.click({ timeout: 1000 });
 
     // expect the user to not exist any more
-    await expect(async () => {
-      await users.exists(admin, data.jannikaData);
-    }).rejects.toThrow();
+    await expect(users.exists(admin, data.jannikaData)).rejects.toThrow();
 
     await rooms.remove(admin, data.room);
 

--- a/tests/mutating/main/users_csv_and_delete.spec.ts
+++ b/tests/mutating/main/users_csv_and_delete.spec.ts
@@ -9,7 +9,7 @@ import * as browsers from '../../shared/page_interactions/browsers';
 import * as users from '../../shared/page_interactions/users';
 import * as rooms from '../../shared/page_interactions/rooms';
 
-// force these tests to run sqeuentially
+// force these tests to run sequentially
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Upload user csv, delete that user', () => {
@@ -26,7 +26,6 @@ test.describe('Upload user csv, delete that user', () => {
     await browsers.pickle();
   });
 
-  //
   test('Admin can upload a user csv', async () => {
     const sym = shared.gensym();
     data.jannikaData = {
@@ -35,11 +34,11 @@ test.describe('Upload user csv, delete that user', () => {
       displayName: 'jannika' + sym,
       role: 20,
       password: 'aula-jannika' + sym,
-      about: 'jannika',
+      about: 'generated in e2e tests',
     };
-    //
+
     const csv_str = `realname;displayname;username;email;about_me
-${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.username};;generated_testing`;
+${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.username};;${data.jannikaData.about}`;
 
     data.room = {
       name: 'room-' + shared.getRunId() + '-csv' + shared.gensym(),
@@ -48,13 +47,13 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     };
 
     const host = shared.getHost();
-
     const admin = await browsers.newPage(browsers.admins_browser);
-
     await admin.goto(host);
 
+    // create a room for CSV import placement
     await rooms.create(admin, data.room);
 
+    // navigate to settings
     await users.goToSettings(admin);
 
     // open benutzer accordeon
@@ -62,32 +61,33 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     await expect(BenutzerAccordeon).toBeVisible();
     await BenutzerAccordeon.click({ timeout: 1000 });
 
+    // upload users click
     const UploadButton = admin.getByTestId('upload-users-csv-button');
     await expect(UploadButton).toBeVisible();
     await UploadButton.click({ timeout: 1000 });
 
+    // create and choose the file
     const filePath = path.join(__dirname, 'temp-upload.txt');
     fs.writeFileSync(filePath, csv_str);
-
     await admin.setInputFiles('input[type="file"]', filePath);
 
-    //
+    // focus room selector
     const RoomSelector = admin.locator('[data-testid="user-room-select"] input');
     await expect(RoomSelector).toBeVisible({ timeout: 500 });
-
     await RoomSelector.click({ timeout: 1000 });
 
     // just select the first room
     await admin.getByRole('option').first().click({ timeout: 1000 });
 
+    // confirm csv upload
     const ApproveButton = admin.locator('[data-testid="confirm_upload"]');
     await expect(ApproveButton).toBeVisible();
     await ApproveButton.click({ timeout: 1000 });
 
     fs.unlinkSync(filePath);
 
+    // verify user is added
     await sleep(1);
-
     await users.exists(admin, data.jannikaData);
 
     admin.close();
@@ -126,6 +126,7 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     await expect(BenutzerAccordeon).toBeVisible();
     await BenutzerAccordeon.click({ timeout: 1000 });
 
+    // click request deletion
     const RequestDeletionButton = jannika.getByTestId('delete-account-button');
     await expect(RequestDeletionButton).toBeVisible();
     await RequestDeletionButton.click({ timeout: 1000 });
@@ -133,22 +134,23 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     const ModalDiv = jannika.locator('div[role="dialog"]');
     await expect(ModalDiv).toBeVisible();
 
+    // confirm deletion request
     const SecondApproveButton = ModalDiv.getByTestId('delete-button').first();
     await expect(SecondApproveButton).toBeVisible();
     await SecondApproveButton.click({ timeout: 1000 });
 
     // admin actions
-
     await users.goToRequests(admin);
-
     await sleep(1);
 
+    // find deletion request
     const AnfrageDiv = admin
       .locator('div')
       .filter({ hasText: `Kontolöschungsanfrage für ${data.jannikaData.displayName}` })
       .first();
     await expect(AnfrageDiv).toBeVisible();
 
+    // click approve
     const ApproveButton = AnfrageDiv.getByTestId('confirm-request').first();
     await expect(ApproveButton).toBeVisible();
     await ApproveButton.click({ timeout: 1000 });
@@ -156,6 +158,7 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     const ModalDiv2 = admin.locator('div[role="dialog"]');
     await expect(ModalDiv2).toBeVisible();
 
+    // confirm approval
     const SecondApproveButton2 = ModalDiv2.getByTestId('confirm-request-action').first();
     await expect(SecondApproveButton2).toBeVisible();
     await SecondApproveButton2.click({ timeout: 1000 });

--- a/tests/mutating/main/users_csv_and_delete.spec.ts
+++ b/tests/mutating/main/users_csv_and_delete.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect, BrowserContext, Page, chromium, Browser } from '@playwright/test';
+import { test, expect, chromium } from '@playwright/test';
 import { sleep } from '../../shared/utils';
 import * as shared from '../../shared/shared';
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 import * as fixtures from '../../fixtures/users';
 import * as browsers from '../../shared/page_interactions/browsers';
@@ -34,7 +34,7 @@ test.describe('Upload user csv, delete that user', () => {
       realName: 'jannika' + sym,
       displayName: 'jannika' + sym,
       role: 20,
-      password: 'aula',
+      password: 'aula-jannika' + sym,
       about: 'jannika',
     };
     //
@@ -89,8 +89,6 @@ ${data.jannikaData.realName};${data.jannikaData.displayName};${data.jannikaData.
     await sleep(1);
 
     await users.exists(admin, data.jannikaData);
-
-    await expect(1).toBeDefined();
 
     admin.close();
   });

--- a/tests/mutating/teardown-auth.ts
+++ b/tests/mutating/teardown-auth.ts
@@ -1,9 +1,5 @@
 // called from playwright.config
-import { test, expect, BrowserContext, Page, chromium, Browser } from '@playwright/test';
-import { sleep } from '../shared/utils';
-import * as shared from '../shared/shared';
 import * as users from '../shared/page_interactions/users';
-import * as rooms from '../shared/page_interactions/rooms';
 import * as fixtures from '../fixtures/users';
 import * as browsers from '../shared/page_interactions/browsers';
 

--- a/tests/shared/page_interactions/users.ts
+++ b/tests/shared/page_interactions/users.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import * as shared from '../shared';
 import * as users from '../../fixtures/users';
+import { sleep } from '../utils';
 
 const host = shared.getHost();
 
@@ -69,6 +70,7 @@ export const exists = async (page: Page, data: users.UserData) => {
 
   // filter by our user name
   await page.fill('#filter-value-input', data.username);
+  await sleep(1);
 
   // find the new user in the user table
   const row = page.locator('table tr').filter({ hasText: data.username });
@@ -153,7 +155,6 @@ export const remove = async (page: Page, data: users.UserData) => {
   await FilterButton.click({ timeout: 1000 });
 
   // select "username" from the "filter by" dropdown
-
   await page.locator('#filter-field-select').click({ timeout: 1000 });
   await page.locator('li[data-value="username"]').click({ timeout: 1000 });
 
@@ -161,7 +162,6 @@ export const remove = async (page: Page, data: users.UserData) => {
   await page.fill('#filter-value-input', data.username);
 
   // find the user's row in the table and select the checkbox for actions
-
   const row = page.locator('table tr').filter({ hasText: data.username });
   const checkbox = row.locator('input');
   await expect(checkbox).toBeVisible();
@@ -170,16 +170,15 @@ export const remove = async (page: Page, data: users.UserData) => {
   // click the remove use button
   const ButtonRemoveUser = page.getByTestId('remove-users-button');
   expect(ButtonRemoveUser).toBeDefined();
-
   await ButtonRemoveUser.click({ timeout: 1000 });
 
+  // confirm deletion
   const ButtonConfirmDelete = page.getByTestId('confirm-delete-users-button');
-
   expect(ButtonConfirmDelete).toBeDefined();
-
   await ButtonConfirmDelete.click({ timeout: 1000 });
 
   // confirm the user does not show up in the table list
+  await sleep(1);
   await expect(page.locator('table tr').filter({ hasText: data.username })).toHaveCount(0);
 };
 
@@ -188,8 +187,7 @@ export const login = async (page: Page, data: users.UserData) => {
   await page.goto(host);
   await page.fill('input[name="username"]', data.username);
   await page.fill('input[name="password"]', data.password);
-
-  await page.locator('button[type="submit"]').click({ timeout: 1000 });
+  await page.getByRole('button', { name: 'Login' }).click({ timeout: 1000 });
 
   // Wait for successful login by checking for the rooms page heading
   await expect(page.locator('#rooms-heading')).toBeVisible();

--- a/tests/shared/page_interactions/users.ts
+++ b/tests/shared/page_interactions/users.ts
@@ -64,7 +64,6 @@ export const exists = async (page: Page, data: users.UserData) => {
   await FilterButton.click({ timeout: 1000 });
 
   // select "username" from the "filter by" dropdown
-
   await page.locator('#filter-field-select').click({ timeout: 1000 });
   await page.locator('li[data-value="username"]').click({ timeout: 1000 });
 

--- a/tests/shared/page_interactions/users.ts
+++ b/tests/shared/page_interactions/users.ts
@@ -1,7 +1,6 @@
 import { expect, Page } from '@playwright/test';
 import * as shared from '../shared';
 import * as users from '../../fixtures/users';
-import { sleep } from '../utils';
 
 const host = shared.getHost();
 
@@ -69,7 +68,6 @@ export const exists = async (page: Page, data: users.UserData) => {
 
   // filter by our user name
   await page.fill('#filter-value-input', data.username);
-  await sleep(1);
 
   // find the new user in the user table
   const row = page.locator('table tr').filter({ hasText: data.username });
@@ -177,7 +175,6 @@ export const remove = async (page: Page, data: users.UserData) => {
   await ButtonConfirmDelete.click({ timeout: 1000 });
 
   // confirm the user does not show up in the table list
-  await sleep(1);
   await expect(page.locator('table tr').filter({ hasText: data.username })).toHaveCount(0);
 };
 

--- a/tests/shared/page_interactions/users.ts
+++ b/tests/shared/page_interactions/users.ts
@@ -186,7 +186,7 @@ export const login = async (page: Page, data: users.UserData) => {
   await page.goto(host);
   await page.fill('input[name="username"]', data.username);
   await page.fill('input[name="password"]', data.password);
-  await page.getByRole('button', { name: 'Login' }).click({ timeout: 1000 });
+  await page.locator('button[type="submit"]').click({ timeout: 1000 });
 
   // Wait for successful login by checking for the rooms page heading
   await expect(page.locator('#rooms-heading')).toBeVisible();

--- a/tests/shared/shared.ts
+++ b/tests/shared/shared.ts
@@ -27,7 +27,7 @@ export const setRunId = () => fs.writeFileSync('run-id.txt', 'run-id-' + timesta
 
 export function gensym(prefix = 'GG') {
   // tests will fail on collision.. very rare
-  const rand = Math.random().toString(36).slice(2, 10); // letters + digits
+  const rand = Math.random().toString(36).slice(2, 18); // letters + digits
   return `${prefix}${rand}`;
 }
 


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Changes CSV import method used on the API, passes list of Rooms for bulk import of all Users from the CSV into all selected Rooms.

## TODO

Add e2e test for multi room

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [ ] ~Backward and forward compatible with BE~ **NOT backward compatible, BE needs to be deployed first, after merging https://github.com/aula-app/aula-backend/pull/259**
- [ ] ~Doesn't need update in the database or BE~ **NOT backward compatible, BE needs to be deployed first, after merging https://github.com/aula-app/aula-backend/pull/259**
- [ ] Must be deployed ASAP (HOTFIX)
