### PR TITLE
FEAT: add datetimepicker for user invite on CSV upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.6
+
+- **New features:**
+  - Scheduled invite for users uploaded via CSV
+
 ## 1.4.5
 
 - **Bug fixes:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aula",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "aula: gemeinsam gestalten",
   "author": {
     "name": "Aula App",

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -533,6 +533,7 @@
       "endTime": "Endzeit",
       "phase": "Phasendauern",
       "startDate": "Startdatum",
+      "inviteDate": "Einladungsdatum für neue Benutzer",
       "startDay": "Starttag",
       "startTime": "Startzeit",
       "workdays": "Arbeitstage",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -533,6 +533,7 @@
       "endTime": "Ending time",
       "phase": "Phase durations",
       "startDate": "Start Date",
+      "inviteDate": "New Users Invite Date",
       "startDay": "Starting day",
       "startTime": "Starting time",
       "workdays": "Work Days",

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -86,7 +86,12 @@ async function setAllowRegistration(status: boolean): Promise<DefaultSettingsRes
   return response as DefaultSettingsResponse;
 }
 
-export async function addAllCSV(csv: string, room_ids: Array<string>, user_level: RoleTypes): Promise<GenericResponse> {
+export async function addAllCSV(
+  csv: string,
+  room_ids: Array<string>,
+  user_level: RoleTypes,
+  send_emails_at?: string
+): Promise<GenericResponse> {
   const response = await databaseRequest({
     model: 'User',
     method: 'addAllCSV',
@@ -94,6 +99,7 @@ export async function addAllCSV(csv: string, room_ids: Array<string>, user_level
       csv,
       room_ids,
       user_level,
+      send_emails_at,
     },
   });
 

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -7,11 +7,11 @@ export const DEFAULT_FORMAT_DATE_ONLY = 'YYYY-MM-DD';
 // Locale-specific date formats
 export const DATE_FORMATS = {
   en: {
-    dateTime: 'MM/DD/YYYY HH:mm:ss', // 01  2025 14:30:00
-    dateOnly: 'MM/DD/YYYY', // 01 June 2025
+    dateTime: DEFAULT_FORMAT_DATE_TIME,
+    dateOnly: DEFAULT_FORMAT_DATE_ONLY,
   },
   de: {
-    dateTime: 'DD.MM.YYYY HH:mm:ss', // German format
+    dateTime: 'DD.MM.YYYY HH:mm:ss',
     dateOnly: 'DD.MM.YYYY',
   },
   // Add more locales as needed

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -7,8 +7,8 @@ export const DEFAULT_FORMAT_DATE_ONLY = 'YYYY-MM-DD';
 // Locale-specific date formats
 export const DATE_FORMATS = {
   en: {
-    dateTime: 'DD MMMM YYYY HH:mm:ss',  // 01 June 2025 14:30:00
-    dateOnly: 'DD MMMM YYYY',           // 01 June 2025
+    dateTime: 'MM/DD/YYYY HH:mm:ss', // 01  2025 14:30:00
+    dateOnly: 'MM/DD/YYYY', // 01 June 2025
   },
   de: {
     dateTime: 'DD.MM.YYYY HH:mm:ss', // German format

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -7,8 +7,8 @@ export const DEFAULT_FORMAT_DATE_ONLY = 'YYYY-MM-DD';
 // Locale-specific date formats
 export const DATE_FORMATS = {
   en: {
-    dateTime: DEFAULT_FORMAT_DATE_TIME,
-    dateOnly: DEFAULT_FORMAT_DATE_ONLY,
+    dateTime: 'DD MMMM YYYY HH:mm:ss',  // 01 June 2025 14:30:00
+    dateOnly: 'DD MMMM YYYY',           // 01 June 2025
   },
   de: {
     dateTime: 'DD.MM.YYYY HH:mm:ss',

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 const TimeCommandInput = ({ onReload }: Props) => {
   const { t } = useTranslation();
-  const { formatDateTime, formatDateOnly } = useDateFormatters();
+  const { formatDateTime } = useDateFormatters();
 
   const [scope, setScope] = useState<number>(0);
   const [target, setTarget] = useState<string | undefined>();
@@ -185,7 +185,7 @@ const TimeCommandInput = ({ onReload }: Props) => {
             label={t(`settings.time.startDate`)}
             value={dayjs(startTime)}
             disabled={typeof action !== 'number'}
-            format={DATE_FORMATS[i18next.languages[0] as LanguageTypes].dateOnly}
+            format={DATE_FORMATS[i18next.language as LanguageTypes].dateOnly}
             onChange={(date) => {
               if (date) setStartTime(dayjs(date).format(DEFAULT_FORMAT_DATE_TIME));
             }}

--- a/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
+++ b/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
@@ -22,7 +22,7 @@ import dayjs from 'dayjs';
 import i18next from 'i18next';
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DATE_FORMATS } from '@/utils/units';
+import { DATE_FORMATS, DEFAULT_FORMAT_DATE_TIME } from '@/utils/units';
 import { LanguageTypes } from '@/types/Translation';
 
 interface Props {
@@ -102,7 +102,10 @@ const DataSettings = ({ onReload }: Props) => {
 
   const uploadCSV = async (csv: string) => {
     setLoading(true);
-    const send_emails_at = inviteDate === null || inviteDate <= dayjs() ? undefined : inviteDate.toISOString();
+    const send_emails_at =
+      inviteDate === null || inviteDate <= dayjs()
+        ? undefined
+        : dayjs(inviteDate).utc().format(DEFAULT_FORMAT_DATE_TIME);
     const response = await addAllCSV(csv, rooms.add, role, send_emails_at);
     setLoading(false);
     if (!response.data) {

--- a/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
+++ b/src/views/Settings/Config/UsersSettings/UsersSettings.tsx
@@ -16,8 +16,14 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import i18next from 'i18next';
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DATE_FORMATS } from '@/utils/units';
+import { LanguageTypes } from '@/types/Translation';
 
 interface Props {
   onReload: () => void;
@@ -32,6 +38,7 @@ const DataSettings = ({ onReload }: Props) => {
   const [users, setUsers] = useState<Array<string>>([]);
   const [role, setRole] = useState<RoleTypes>(20);
   const [rooms, setRooms] = useState<UpdateType>({ add: [], remove: [] });
+  const [inviteDate, setInviteDate] = useState<dayjs.Dayjs | null>(dayjs());
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -95,7 +102,9 @@ const DataSettings = ({ onReload }: Props) => {
 
   const uploadCSV = async (csv: string) => {
     setLoading(true);
-    const response = await addAllCSV(csv, rooms.add, role);
+    const send_emails_at = inviteDate === null || inviteDate <= dayjs() ? undefined : inviteDate.toISOString();
+    console.log(csv, rooms.add, role, `send_emails_at: ${send_emails_at}`);
+    const response = await addAllCSV(csv, rooms.add, role, send_emails_at);
     setLoading(false);
     if (!response.data) {
       dispatch({ type: 'ADD_POPUP', message: { message: t('errors.default'), type: 'error' } });
@@ -169,7 +178,7 @@ const DataSettings = ({ onReload }: Props) => {
         </TableBody>
       </Table>
 
-      <Stack>
+      <Stack gap={2}>
         <Stack direction="row" alignItems="center" gap={3}>
           <SelectRole
             userRole={role}
@@ -184,8 +193,18 @@ const DataSettings = ({ onReload }: Props) => {
             onChange={(updates) => setRooms(updates)}
             disabled={loading}
           />
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <DateTimePicker
+              label={t('settings.time.inviteDate')}
+              value={inviteDate}
+              onChange={setInviteDate}
+              format={DATE_FORMATS[i18next.language as LanguageTypes].dateTime}
+              sx={{ minWidth: 200 }}
+              data-testid="user-invite-date-picker"
+            />
+          </LocalizationProvider>
         </Stack>
-        <FormHelperText error={error !== ''}>{`${error || ''}`}</FormHelperText>
+        {error !== '' && <FormHelperText error={error !== ''}>{`${error || ''}`}</FormHelperText>}
       </Stack>
       <Button data-testid="confirm_upload" variant="contained" component="label" onClick={onSubmit} disabled={loading}>
         {loading ? t('status.waiting') : t('actions.confirm')}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Add datetimepicker for user invite on CSV upload

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- ~[ ] Backward and forward compatible with BE~ **depends on this one https://github.com/aula-app/aula-backend/pull/285**
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
