### PR TITLE
fix: missing translations for announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.4.6
+## next_release
+
+- **Bug fixes**
+  - Add translations for empty announcements page
+
+## 1.5.0
 
 - **New features:**
   - Scheduled invite for users uploaded via CSV

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -660,6 +660,10 @@
     },
     "darkMode": "Dunkelmodus",
     "empty": {
+      "announcements": {
+        "description": "Es wurden noch keine Ankündigungen erstellt.",
+        "title": "Keine Ankündigungen"
+      },
       "boxes": {
         "description": "Boxen werden hier angezeigt, wenn sie diese Phase erreichen",
         "title": "Keine Boxen in dieser Phase"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -660,6 +660,10 @@
     },
     "darkMode": "Dark mode",
     "empty": {
+      "announcements": {
+        "description": "There are no announcements created yet",
+        "title": "No announcements"
+      },
       "boxes": {
         "description": "Boxes will appear here when they reach this phase",
         "title": "No boxes in this phase"


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [/] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [/] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with BE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)