### PR TITLE
feat: Add row limit selector for settings' tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next_release
 
+- **New features:**
+  - Table number of rows selector
 - **Bug fixes**
   - Add translations for empty announcements page
 

--- a/src/components/DataTable/PaginationBar.tsx
+++ b/src/components/DataTable/PaginationBar.tsx
@@ -1,19 +1,47 @@
-import { Pagination, Stack } from '@mui/material';
+import { Pagination, Stack, TextField, Typography } from '@mui/material';
 import { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   pages: number;
   setPage: (page: number) => void;
+  limit?: number;
+  setLimit?: (limit: number) => void;
 };
 
-const PaginationBar: React.FC<Props> = ({ pages, setPage }) => {
+const PaginationBar: React.FC<Props> = ({ pages, setPage, limit, setLimit }) => {
+  const { t } = useTranslation();
+
   const changePage = (event: ChangeEvent<unknown>, newPage: number) => {
     setPage(newPage - 1);
   };
 
-  return pages > 1 ? (
-    <Stack direction="row" alignItems="center" justifyContent="center" bottom={0} height={48}>
-      <Pagination count={pages} onChange={changePage} sx={{ py: 1 }} />
+  const changeLimit = (event: ChangeEvent<HTMLInputElement>) => {
+    if (setLimit) {
+      const value = Number(event.target.value);
+      if (value > 0) {
+        setLimit(value);
+        setPage(0); // Reset to first page when limit changes
+      }
+    }
+  };
+
+  return pages > 1 || (limit && setLimit) ? (
+    <Stack direction="row" alignItems="center" justifyContent="space-between" bottom={0} height={48}>
+      {limit && setLimit && (
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ px: 2 }}>
+          <Typography variant="body2">{t('ui.pagination.rowsPerPage')}</Typography>
+          <TextField
+            type="number"
+            value={limit}
+            onChange={changeLimit}
+            size="small"
+            slotProps={{ htmlInput: { min: 1, style: { textAlign: 'center' } } }}
+            sx={{ width: 70 }}
+          />
+        </Stack>
+      )}
+      {pages > 1 && <Pagination count={pages} onChange={changePage} sx={{ py: 1 }} />}
     </Stack>
   ) : null;
 };

--- a/src/components/DataTable/PaginationBar.tsx
+++ b/src/components/DataTable/PaginationBar.tsx
@@ -19,7 +19,7 @@ const PaginationBar: React.FC<Props> = ({ pages, setPage, limit, setLimit }) => 
   const changeLimit = (event: ChangeEvent<HTMLInputElement>) => {
     if (setLimit) {
       const value = Number(event.target.value);
-      if (value > 0) {
+      if (!!value && typeof value === 'number' && value > 0) {
         setLimit(value);
         setPage(0); // Reset to first page when limit changes
       }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -723,6 +723,9 @@
       "upload": "Datei hochladen"
     },
     "lightMode": "Hellermodus",
+    "pagination": {
+      "rowsPerPage": "Zeilen pro Seite:"
+    },
     "navigation": {
       "about": "Über",
       "announcements": "Ankündigungen",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -723,6 +723,9 @@
       "upload": "File upload"
     },
     "lightMode": "Light mode",
+    "pagination": {
+      "rowsPerPage": "Rows per page:"
+    },
     "navigation": {
       "about": "About",
       "announcements": "Announcements",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,5 +2,5 @@
 export const IS_SERVER = typeof window === 'undefined';
 
 export function getDataLimit(): number {
-  return Math.floor((window.innerHeight - 285) / 55 - 1);
+  return Math.max(1, Math.floor((window.innerHeight - 285) / 55 - 1));
 }

--- a/src/views/Settings/Announcements/AnnouncementsView.tsx
+++ b/src/views/Settings/Announcements/AnnouncementsView.tsx
@@ -131,7 +131,12 @@ const AnnouncementsView: React.FC = () => {
           setDelete={deleteAnnouncements}
           isLoading={isLoading}
         />
-        <PaginationBar pages={Math.ceil(totalAnnouncements / limit)} setPage={(page) => setOffset(page * limit)} />
+        <PaginationBar
+          pages={Math.ceil(totalAnnouncements / limit)}
+          setPage={(page) => setOffset(page * limit)}
+          limit={limit}
+          setLimit={setLimit}
+        />
       </Stack>
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <AnnouncementForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />

--- a/src/views/Settings/Boxes/BoxesView.tsx
+++ b/src/views/Settings/Boxes/BoxesView.tsx
@@ -119,7 +119,12 @@ const BoxesView: React.FC = () => {
           setDelete={deleteBoxes}
           isLoading={isLoading}
         />
-        <PaginationBar pages={Math.ceil(totalBoxes / limit)} setPage={(page) => setOffset(page * limit)} />
+        <PaginationBar
+          pages={Math.ceil(totalBoxes / limit)}
+          setPage={(page) => setOffset(page * limit)}
+          limit={limit}
+          setLimit={setLimit}
+        />
       </Stack>
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <BoxForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />

--- a/src/views/Settings/Ideas/IdeasView.tsx
+++ b/src/views/Settings/Ideas/IdeasView.tsx
@@ -122,7 +122,12 @@ const IdeasView: React.FC = () => {
           extraTools={extraTools}
           isLoading={isLoading}
         />
-        <PaginationBar pages={Math.ceil(totalIdeas / limit)} setPage={(page) => setOffset(page * limit)} />
+        <PaginationBar
+          pages={Math.ceil(totalIdeas / limit)}
+          setPage={(page) => setOffset(page * limit)}
+          limit={limit}
+          setLimit={setLimit}
+        />
       </Stack>
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <IdeaForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />

--- a/src/views/Settings/Messages/MessagesView.tsx
+++ b/src/views/Settings/Messages/MessagesView.tsx
@@ -112,7 +112,12 @@ const MessagesView: React.FC = () => {
           setDelete={deleteMessages}
           isLoading={isLoading}
         />
-        <PaginationBar pages={Math.ceil(totalMessages / limit)} setPage={(page) => setOffset(page * limit)} />
+        <PaginationBar
+          pages={Math.ceil(totalMessages / limit)}
+          setPage={(page) => setOffset(page * limit)}
+          limit={limit}
+          setLimit={setLimit}
+        />
       </Stack>
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <MessageForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />

--- a/src/views/Settings/Rooms/RoomsView.tsx
+++ b/src/views/Settings/Rooms/RoomsView.tsx
@@ -113,7 +113,12 @@ const RoomsView: React.FC = () => {
           setDelete={deleteRooms}
           isLoading={isLoading}
         />
-        <PaginationBar pages={Math.ceil(totalRooms / limit)} setPage={(page) => setOffset(page * limit)} />
+        <PaginationBar
+          pages={Math.ceil(totalRooms / limit)}
+          setPage={(page) => setOffset(page * limit)}
+          limit={limit}
+          setLimit={setLimit}
+        />
       </Stack>
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <RoomForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />

--- a/src/views/Settings/Users/UsersView.tsx
+++ b/src/views/Settings/Users/UsersView.tsx
@@ -138,7 +138,12 @@ const UsersView: React.FC = () => {
           onReload={fetchUsers}
         />
       </Stack>
-      <PaginationBar pages={Math.ceil(totalUsers / limit)} setPage={(page) => setOffset(page * limit)} />
+      <PaginationBar
+        pages={Math.ceil(totalUsers / limit)}
+        setPage={(page) => setOffset(page * limit)}
+        limit={limit}
+        setLimit={setLimit}
+      />
       <Drawer anchor="bottom" open={!!edit} onClose={onClose} sx={{ overflowY: 'auto' }}>
         <UserForms onClose={onClose} defaultValues={typeof edit !== 'boolean' ? edit : undefined} />
       </Drawer>


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Add row limit selector for settings' tables

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
