### PR TITLE
fix(tests): Use an user password with the correct length to be accepted by the backend

### DIFF
--- a/tests/specs/core/profile-change-pass.spec.ts
+++ b/tests/specs/core/profile-change-pass.spec.ts
@@ -2,6 +2,7 @@ import { expect, Page } from '@playwright/test';
 import { test } from '../../fixtures/test-fixtures';
 import * as formInteractions from '../../interactions/forms';
 import * as navigation from '../../interactions/navigation';
+import { TestConstants } from '../../support/config';
 
 type PasswordChangeContext = {
   oldPassword: string;
@@ -19,7 +20,7 @@ type PasswordChangeContext = {
  */
 test.describe.serial('Change pass flow', () => {
   const defaultFields = {
-    oldPassword: 'aula',
+    oldPassword: TestConstants.DEFAULT_PASSWORD,
     newPassword: 'newPassword0',
     confirmPassword: 'newPassword0',
   };

--- a/tests/support/config.ts
+++ b/tests/support/config.ts
@@ -9,7 +9,7 @@ export const TestConstants = {
   NAVIGATION_TIMEOUT: 5000,
 
   // Test data
-  DEFAULT_PASSWORD: 'aula',
+  DEFAULT_PASSWORD: 'aulapassword123',
   TEST_DESCRIPTION: 'created during automated testing',
 
   // Box settings


### PR DESCRIPTION
Tests were failing because now the user must have a password with more than or equal 12 characters.

Fix #947 

## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page. This PR changes the way we store them using MethodX.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
