### PR TITLE
Parse user roles when they are string in JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.2
+
+- **Bug fixes**
+  - Parse user roles correctly from JWT when they are strings
+
 ## 1.7.1
 
 - **Technical improvements**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aula",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "aula: gemeinsam gestalten",
   "author": {
     "name": "Aula App",

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -170,9 +170,15 @@ export function checkPermissions(model: keyof typeof permissions, action: string
       const rooms = user.roles.filter((r) => r.room == room_id);
       if (rooms.length < 1) return false;
 
+
       const roleInRoom = rooms[0].role;
+      // In some cases we are saving the user roles as a string instead of a number in the JWT.
+      // We need to parse it in these cases. TODO: check in the backend why this happens. The
+      // issue appears for users created with CSV import
+      const roleInRoomNumber = ((typeof roleInRoom === 'string') ? parseInt(roleInRoom, 10): roleInRoom) as RoleTypes;
+
       const hasRolePermission =
-        typeof permissionRole === 'number' ? roleInRoom >= permissionRole : permissionRole.includes(roleInRoom);
+        typeof permissionRole === 'number' ? roleInRoomNumber >= permissionRole : permissionRole.includes(roleInRoomNumber);
 
       return checkSelfPermission(hasRolePermission);
     }


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fix #993 

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
