### PR TITLE
fix: stop requesting `/api/files/` for non-existent avatars

### DIFF
--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -38,7 +38,7 @@ const UserAvatar = ({ id, size = 32, sx, ...restOfProps }: Props) => {
         ...sx,
       }}
       alt={t('user.avatar', { id: id })}
-      src={`${api_url}/api/files/${code}/${userAvatar}` || ''}
+      src={userAvatar ? `${api_url}/api/files/${code}/${userAvatar}` : ''}
       {...restOfProps}
     >
       {!userAvatar && <AppIcon icon="avatar" />}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fixes https://github.com/aula-app/aula-frontend/issues/590

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
