### PR TITLE
fix: use prebuild ansible image for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,31 +12,29 @@ env:
 jobs:
   run-aula:
     runs-on: [self-hosted, cicd]
+    permissions:
+      contents: read
+      packages: read
     env:
-      COMPOSE_NAME: aula-e2e-${{ github.sha }}
-      AULA_IMAGE: aula-ansible:${{ github.sha }}
+      COMPOSE_NAME: aula-e2e-${{ github.ref_name }}
+      AULA_IMAGE: ghcr.io/aula-app/ansible-role-aula:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Create roles folder
-        run: |
-          mkdir -p ./roles
-
-      - name: Checkout aula role
-        uses: actions/checkout@v6
-        with:
-          repository: aula-app/ansible-role-aula
-          ssh-key: "${{ secrets.ANSIBLE_DEPLOY_KEY }}"
-          path: ./roles/ansible-role-aula
-
-      # TODO: Build in ansible-role-aula repo
-      - name: Setup docker builder
+      - name: Setup docker
         uses: docker/setup-buildx-action@v4
 
-      - name: Build ansible container image
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Ansible image
         run: |
-          docker build -f ./roles/ansible-role-aula/.docker/Dockerfile -t ${{ env.AULA_IMAGE }} ./roles/ansible-role-aula/
+          docker pull ${{ env.AULA_IMAGE }}
 
       - name: Create Ansible playbook
         run: |


### PR DESCRIPTION
## Context

Use the container image build in the ansible-role-aula repo instead of building it on every pipeline run.