### PR TITLE
Feat: Prevet editing on voting phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **New features**
   - Reset multiple users' password button on User Settings
+  - Prevent users from editing ideas after voting phase
 
 ## 1.8.3
 

--- a/src/components/MoreOptions/MoreOptions.tsx
+++ b/src/components/MoreOptions/MoreOptions.tsx
@@ -64,17 +64,16 @@ const MoreOptions: React.FC<Props> = ({ item, scope, children, onDelete, onEdit,
               role="menuitem"
               data-testid={`report-button`}
             />
-            {phase && (
-              <>
-                {checkPermissions(scope, 'edit', 'user_hash_id' in item ? item.user_hash_id : undefined) && (
+            {phase &&
+              checkPermissions(scope, 'edit', 'user_hash_id' in item ? item.user_hash_id : undefined) &&
+              Number(phase) < 30 && (
+                <>
                   <EditButton
                     color={color || 'secondary'}
                     onEdit={onEdit}
                     role="menuitem"
                     data-testid={`edit-button`}
                   />
-                )}
-                {checkPermissions(scope, 'delete', 'user_hash_id' in item ? item.user_hash_id : undefined) && (
                   <DeleteButton
                     color={color || 'error'}
                     scope={scope}
@@ -82,9 +81,8 @@ const MoreOptions: React.FC<Props> = ({ item, scope, children, onDelete, onEdit,
                     role="menuitem"
                     data-testid={`delete-button`}
                   />
-                )}
-              </>
-            )}
+                </>
+              )}
           </Stack>
         </Collapse>
         <AppIconButton


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

User shouldnt be able to edit their ideas ones they went to voting phase

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
