### PR TITLE
Fix: Phase duration on boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **New features**
   - Reset multiple users' password button on User Settings
+- **Bug fixes**
+  - Default phase durations from room was not affecting new boxes
 
 ## 1.8.3
 

--- a/src/components/DataFields/PhaseDurationFields.tsx
+++ b/src/components/DataFields/PhaseDurationFields.tsx
@@ -41,11 +41,14 @@ const PhaseDurationFields: React.FC<Props> = ({
     { name: 'phase_duration_3', phase: 30 },
   ] as Array<{ name: 'phase_duration_1' | 'phase_duration_3'; phase: RoomPhases }>;
 
-  const getDurations = () => {
-    fields.forEach((field) => {
-      if (control._defaultValues[field.name]) return; // Skip if already set
-      setValue(field.name, getDefaultDuration(field.name));
-    });
+  const getDurations = async () => {
+    await Promise.all(
+      fields.map(async (field) => {
+        if (control._defaultValues[field.name]) return; // Skip if already set
+        const duration = await getDefaultDuration(field.name);
+        setValue(field.name, duration);
+      })
+    );
   };
 
   const getDefaultDuration = async (phase: 'phase_duration_1' | 'phase_duration_3') => {
@@ -63,7 +66,7 @@ const PhaseDurationFields: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    getDurations();
+    void getDurations();
   }, [room, room_id]);
 
   return (


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Default phase durations from room was not affecting new boxes

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
