### PR TITLE
Fix: quorum tooltip floating over edit menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **New features**
   - Reset multiple users' password button on User Settings
+- **Bug fixes**
+  - Fix quorum tooltip floating over edit menu
 
 ## 1.8.3
 

--- a/src/components/Idea/VotingQuorum/VotingQuorum.tsx
+++ b/src/components/Idea/VotingQuorum/VotingQuorum.tsx
@@ -22,7 +22,13 @@ const VotingQuorum: React.FC<Props> = ({ phase, users, votes, quorum }) => {
     <Stack pt={2}>
       <Stack sx={{ position: 'relative' }}>
         {quorum > 0 && (
-          <Tooltip title={`${Math.round(quorum)}%`} open={true} placement="bottom" arrow={true}>
+          <Tooltip
+            title={`${Math.round(quorum)}%`}
+            open={true}
+            placement="bottom"
+            arrow={true}
+            slotProps={{ popper: { style: { zIndex: 10 } } }}
+          >
             <Box sx={{ position: 'absolute', left: `${Math.round(quorum)}%` }} />
           </Tooltip>
         )}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Quorum tooltip was being display over edit idea view

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
