### PR TITLE
Fix: long names clipped on password list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **New features**
   - Reset multiple users' password button on User Settings
+- **Bug Fixes**
+  - Fix long names clipped on password list print view
 
 ## 1.8.3
 

--- a/src/components/PrintUsers/PrintUsers.tsx
+++ b/src/components/PrintUsers/PrintUsers.tsx
@@ -28,7 +28,8 @@ const PrintUsers = forwardRef<ButtonProps>(({ ...restOfProps }, ref) => {
 
   const fetchUsers = useCallback(async (roomId: string) => {
     setLoading(true);
-    const response = await getUsers(roomId ? { room_id: roomId } : {});
+    const query = roomId && roomId !== 'all' ? { room_id: roomId } : {};
+    const response = await getUsers(query);
 
     if (response.error) {
       setError(response.error);
@@ -100,6 +101,9 @@ const PrintUsers = forwardRef<ButtonProps>(({ ...restOfProps }, ref) => {
                 text-align: left;
                 max-width: 50%;
                 width: 50%;
+                word-break: break-word;
+                overflow-wrap: anywhere;
+                white-space: normal;
               }
               th {
                 background-color: #f2f2f2;


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Admins could not read long usernames on the password print view

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
