### PR TITLE
fix: wrong 404 message on messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,8 @@ package-lock.json
 
 # misc
 .DS_Store
-.env.local
-.env.development
-.env.development.local
-.env.test.local
-.env.production.local
+*.development
+*.local
 
 vite.config.local.mts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Version management alerts for outdated app version
 
 - **Bug fixes**
+  - Fix wrong 404 message on /messages page showing "no users" instead of "no messages" in German
   - Fix quorum tooltip floating over edit menu
   - Prevent users from editing ideas after voting phase
   - Default phase durations from room was not affecting new boxes

--- a/src/views/Messages/UserMessagesView.tsx
+++ b/src/views/Messages/UserMessagesView.tsx
@@ -39,7 +39,7 @@ const UserMessagesView = () => {
     <Stack gap={1} p={2} sx={{ overflowY: 'auto' }} data-testid="user-messages-view">
       <Typography variant="h1">{t('scopes.messages.plural')}</Typography>
       {!isLoading && !error && messages.length === 0 && (
-        <EmptyState title={t('ui.empty.users.title')} description={t('ui.empty.users.description')} />
+        <EmptyState title={t('ui.empty.messages.title')} description={t('ui.empty.messages.description')} />
       )}
       {
         <>


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fix wrong 404 message on /messages page showing "no users" instead of "no messages"

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
