### PR TITLE
fix: idea edit status change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Prevent users from editing ideas after voting phase
   - Default phase durations from room was not affecting new boxes
   - Fix long names clipped on password list print view
+  - Hide inactive ideas
 
 ## 1.8.3
 

--- a/src/components/DataForms/IdeaForms.tsx
+++ b/src/components/DataForms/IdeaForms.tsx
@@ -143,6 +143,7 @@ const IdeaForms: React.FC<IdeaFormsProps> = ({ defaultValues, onClose }) => {
       custom_field1: data.custom_field1,
       custom_field2: data.custom_field2,
       topic_id: box,
+      status: data.status,
     });
     if (response.error) {
       setError('root', {

--- a/src/components/DataForms/IdeaForms.tsx
+++ b/src/components/DataForms/IdeaForms.tsx
@@ -175,6 +175,7 @@ const IdeaForms: React.FC<IdeaFormsProps> = ({ defaultValues, onClose }) => {
       custom_field2: data.custom_field2,
       idea_id: defaultValues.hash_id,
       approved: defaultValues.approved,
+      status: data.status,
     });
     if (response.error) {
       setError('root', {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Neither addIdea nor editIdea take into account status (they are not sending it in the request to BE).

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
