### PR TITLE
fix: Tech Admin top bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ package-lock.json
 
 # misc
 .DS_Store
-*.development
-*.local
+/*.development
+/*.local
 
 vite.config.local.mts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Prevent users from editing ideas after voting phase
   - Default phase durations from room was not affecting new boxes
   - Fix long names clipped on password list print view
+  - Fix Tech Admin navigation
 
 ## 1.8.3
 

--- a/src/layout/PrivateLayout/LayoutContainer.tsx
+++ b/src/layout/PrivateLayout/LayoutContainer.tsx
@@ -2,6 +2,7 @@ import SkipNavigation from '@/components/SkipNavigation';
 import AskConsent from '@/views/AskConsent';
 import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 import TopBar from './TopBar';
+import TechTopBar from './TopBar/TechTopBar';
 import { checkPermissions } from '@/utils';
 import SideBar from './SideBar';
 
@@ -62,7 +63,11 @@ const LayoutContainer: FunctionComponent<PropsWithChildren> = ({ children }) => 
   return (
     <div className="flex flex-col h-dvh w-full overflow-hidden">
       <SkipNavigation mainContentId="main-content" />
-      <TopBar mobileMenuOpen={mobileMenuOpen} onToggleMobileMenu={toggleMobileMenu} menuButtonRef={menuButtonRef} />
+      {checkPermissions('system', 'hide') ? (
+        <TechTopBar mobileMenuOpen={mobileMenuOpen} onToggleMobileMenu={toggleMobileMenu} menuButtonRef={menuButtonRef} />
+      ) : (
+        <TopBar mobileMenuOpen={mobileMenuOpen} onToggleMobileMenu={toggleMobileMenu} menuButtonRef={menuButtonRef} />
+      )}
       <div className="flex min-h-0 flex-1 overflow-hidden relative">
         {!checkPermissions('system', 'hide') && (
           <nav

--- a/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
+++ b/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
@@ -1,5 +1,7 @@
 import Icon from '@/components/new/Icon';
 import IconButton from '@/components/new/IconButton';
+import LocaleSwitch from '@/components/LocaleSwitch';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
 import { getRuntimeConfig } from '@/config';
 import { useEventLogout } from '@/hooks';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +30,8 @@ const TechTopBar: React.FC<TopBarProps> = () => {
         <div className="flex-1 flex items-center justify-center h-full overflow-hidden">
           {t('ui.navigation.adminPanel')}
         </div>
+        <LocaleSwitch />
+        <ThemeToggleButton />
         <IconButton onClick={onLogout} aria-label={t('auth.logout')} title={t('auth.logout')}>
           <Icon type="logout" size="1.5rem" aria-hidden="true" />
         </IconButton>

--- a/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
+++ b/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
@@ -1,0 +1,39 @@
+import Icon from '@/components/new/Icon';
+import IconButton from '@/components/new/IconButton';
+import { getRuntimeConfig } from '@/config';
+import { useEventLogout } from '@/hooks';
+import { useTranslation } from 'react-i18next';
+
+interface TopBarProps {
+  mobileMenuOpen?: boolean;
+  onToggleMobileMenu?: () => void;
+  menuButtonRef?: React.RefObject<HTMLButtonElement>;
+}
+
+const TechTopBar: React.FC<TopBarProps> = () => {
+  const { t } = useTranslation();
+  const onLogout = useEventLogout();
+
+  return (
+    <header className="relative bg-primary px-6 py-1 shadow-sm pt-[calc(var(--safe-area-inset-top,0px))] z-30">
+      <div className="relative flex shrink-0 items-center h-14">
+        <div className="flex h-full items-center justify-start">
+          <img
+            src={`${getRuntimeConfig().BASENAME}img/Aula_Icon.svg`}
+            alt={t('app.name.logo')}
+            role="img"
+            className="h-8 w-auto"
+          />
+        </div>
+        <div className="flex-1 flex items-center justify-center h-full overflow-hidden">
+          {t('ui.navigation.adminPanel')}
+        </div>
+        <IconButton onClick={onLogout} aria-label={t('auth.logout')}>
+          <Icon type="logout" size="1.5rem" aria-hidden="true" />
+        </IconButton>
+      </div>
+    </header>
+  );
+};
+
+export default TechTopBar;

--- a/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
+++ b/src/layout/PrivateLayout/TopBar/TechTopBar.tsx
@@ -28,7 +28,7 @@ const TechTopBar: React.FC<TopBarProps> = () => {
         <div className="flex-1 flex items-center justify-center h-full overflow-hidden">
           {t('ui.navigation.adminPanel')}
         </div>
-        <IconButton onClick={onLogout} aria-label={t('auth.logout')}>
+        <IconButton onClick={onLogout} aria-label={t('auth.logout')} title={t('auth.logout')}>
           <Icon type="logout" size="1.5rem" aria-hidden="true" />
         </IconButton>
       </div>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -750,6 +750,7 @@
     },
     "navigation": {
       "about": "Über",
+      "adminPanel": "Admin-Bereich",
       "announcements": "Ankündigungen",
       "boxes": "Boxen",
       "bugs": "Fehler",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -750,6 +750,7 @@
     },
     "navigation": {
       "about": "About",
+      "adminPanel": "Admin Panel",
       "announcements": "Announcements",
       "boxes": "Boxes",
       "bugs": "Bugs",

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -21,7 +21,7 @@ interface DefaultConfigResponse extends GenericResponse {
   data: ConfigResponse;
 }
 
-async function getGlobalConfigs(): Promise<DefaultConfigResponse> {
+export async function getGlobalConfigs(): Promise<DefaultConfigResponse> {
   const response = await databaseRequest({
     model: 'Settings',
     method: 'getGlobalConfig',


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Tech Admins got locked out by new topbar

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
