### PR TITLE
Accessibility: 135 identify input purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
   - Reset multiple users' password button on User Settings
   - Version management alerts for outdated app version
 
+- **Accessibility improvements**
+  - Added `autocomplete` attributes to all form inputs to satisfy WCAG 2.1 AA criterion 1.3.5 (Identify Input Purpose)
+  - Login form identifies username and current password fields for browser autofill and assistive technologies
+  - Set password and change password forms identify new/current password fields for password managers
+  - Profile editor fields mapped to standard tokens (nickname, username, name, email)
+  - Admin user management form opts out of autofill to prevent credential injection when editing other users' data
+
 - **Bug fixes**
   - Fix quorum tooltip floating over edit menu
   - Prevent users from editing ideas after voting phase

--- a/src/components/ChangePassword/ChangePassword.tsx
+++ b/src/components/ChangePassword/ChangePassword.tsx
@@ -135,6 +135,12 @@ const ChangePassword: React.FC<Props> = ({
   // Use shared password requirements function
   const { renderPasswordRequirements } = usePasswordRequirements(watchedNewPassword || '', passwordComplexity, t);
 
+  const autocompleteTokens: Record<keyof typeof fields, string> = {
+    oldPassword: 'current-password',
+    newPassword: 'new-password',
+    confirmPassword: 'new-password',
+  };
+
   const onSubmit = async (data: SchemaType) => {
     const result = await changePassword(data.oldPassword, data.newPassword, tmp_token);
 
@@ -230,6 +236,7 @@ const ChangePassword: React.FC<Props> = ({
                     id: `change-password-${field}-label`,
                     htmlFor: `change-password-${field}`,
                     'data-testid': `${field}-input`,
+                    autoComplete: autocompleteTokens[field],
                   },
                   input: {
                     endAdornment: (

--- a/src/components/DataForms/UserForms.tsx
+++ b/src/components/DataForms/UserForms.tsx
@@ -229,6 +229,7 @@ const UserForms: React.FC<UserFormsProps> = ({ defaultValues, onClose }) => {
                 slotProps={{
                   htmlInput: {
                     'data-testid': 'displayname-input',
+                    autoComplete: 'off',
                   },
                   input: {
                     'aria-labelledby': 'displayname-label',
@@ -258,6 +259,7 @@ const UserForms: React.FC<UserFormsProps> = ({ defaultValues, onClose }) => {
                 slotProps={{
                   htmlInput: {
                     'data-testid': 'username-input',
+                    autoComplete: 'off',
                   },
                   input: {
                     'aria-labelledby': 'username-label',
@@ -287,6 +289,7 @@ const UserForms: React.FC<UserFormsProps> = ({ defaultValues, onClose }) => {
                 slotProps={{
                   htmlInput: {
                     'data-testid': 'realname-input',
+                    autoComplete: 'off',
                   },
                   input: {
                     'aria-labelledby': 'realname-label',
@@ -315,6 +318,7 @@ const UserForms: React.FC<UserFormsProps> = ({ defaultValues, onClose }) => {
                 slotProps={{
                   htmlInput: {
                     'data-testid': 'email-input',
+                    autoComplete: 'off',
                   },
                   input: {
                     'aria-labelledby': 'email-label',

--- a/src/components/ProfileEditor/RestrictedField.tsx
+++ b/src/components/ProfileEditor/RestrictedField.tsx
@@ -16,6 +16,13 @@ interface Props {
 /** * Renders "requests" view
  * url: /settings/requests
  */
+const autocompleteTokens: Partial<Record<keyof PossibleFields, string>> = {
+  displayname: 'nickname',
+  username: 'username',
+  realname: 'name',
+  email: 'email',
+};
+
 const RestrictedField = ({ name, control, ...restOfProps }: Props) => {
   const { t } = useTranslation();
 
@@ -34,6 +41,9 @@ const RestrictedField = ({ name, control, ...restOfProps }: Props) => {
           {...field}
           disabled={disabled}
           slotProps={{
+            htmlInput: {
+              autoComplete: autocompleteTokens[name],
+            },
             input: {
               'aria-labelledby': `profile-${name}-label`,
               endAdornment: (

--- a/src/views/Public/InstanceCodeView.tsx
+++ b/src/views/Public/InstanceCodeView.tsx
@@ -50,6 +50,11 @@ const InstanceCodeView = () => {
         variant="outlined"
         error={!!error}
         helperText={error || t('instance.headline')}
+        slotProps={{
+          input: {
+            autoCapitalize: "none"
+          }
+        }}
         onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
           if (event.key === 'Enter') handleSubmit();
         }}

--- a/src/views/Public/Login/LoginView.tsx
+++ b/src/views/Public/Login/LoginView.tsx
@@ -195,6 +195,7 @@ const LoginView = () => {
                 "aria-labelledby": "login-password-label",
                 "aria-invalid": !!errors.password,
                 "aria-errormessage": errors.password ? "password-error-message" : undefined,
+                autoCapitalize: "none",
                 endAdornment: (
                   <InputAdornment position="end">
                     <AppIconButton

--- a/src/views/Public/Login/LoginView.tsx
+++ b/src/views/Public/Login/LoginView.tsx
@@ -160,6 +160,9 @@ const LoginView = () => {
                 "aria-errormessage": errors.username ? "username-error-message" : undefined,
                 autoCapitalize: "none"
               },
+              htmlInput: {
+                autoComplete: "username"
+              },
               inputLabel: {
                 id: "login-username-label",
                 htmlFor: "login-username"
@@ -185,6 +188,9 @@ const LoginView = () => {
             helperText={<span id="password-error-message">{errors.password?.message || ''}</span>}
             sx={{ mt: 0 }}
             slotProps={{
+              htmlInput: {
+                autoComplete: "current-password"
+              },
               input: {
                 "aria-labelledby": "login-password-label",
                 "aria-invalid": !!errors.password,

--- a/src/views/Public/SetPassword/SetPasswordView.tsx
+++ b/src/views/Public/SetPassword/SetPasswordView.tsx
@@ -101,6 +101,11 @@ const SetPasswordView = () => {
     t
   );
 
+  const autocompleteTokens: Record<keyof typeof fields, string> = {
+    newPassword: 'new-password',
+    confirmPassword: 'new-password',
+  };
+
   const validateKey = async () => {
     if (!key) {
       setValid(false);
@@ -191,6 +196,9 @@ const SetPasswordView = () => {
                   error={!!errors[field]}
                   helperText={<span id={`${field}-error-message`}>{typeof errors[field]?.message === 'string' ? errors[field]?.message : ''}</span>}
                   slotProps={{
+                    htmlInput: {
+                      autoComplete: autocompleteTokens[field],
+                    },
                     input: {
                       'aria-labelledby': `set-password-${field}-label`,
                       'aria-invalid': !!errors[field],


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Form inputs don't specify their purpose using autocomplete attributes, making it difficult for assistive technologies and browsers to help users fill forms.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] Passed automatic tests <!-- you can strikethrough this option in case you haven't run the automatic tests for some reason -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
