### PR TITLE
fix(ci): e2e pipeline failure due to missing config values

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -79,6 +79,10 @@ jobs:
                   email:
                     from: admin@aula.local
                     support: support@aula.local
+                  report:
+                      statistics:
+                        recipients: ""
+                        schedule: "0 2 1 * *"
                   manager:
                     db:
                       name: "aula_manager"


### PR DESCRIPTION
They  got added in the last rebase of ansible-role-aula onto the infra repo.