### PR TITLE
prevent creation of actions in the past

### DIFF
--- a/src/test-ids.ts
+++ b/src/test-ids.ts
@@ -35,6 +35,11 @@ export const TEST_IDS = {
 
   // Offline state (PublicOfflineView)
   SCHOOL_OFFLINE_VIEW: 'school-offline-view',
+
+  // Settings / timed actions (TimedCommands)
+  TIMEDCOMMAND_CONFIRM_BUTTON: 'timedcommand-confirm-button',
+  TIMEDCOMMAND_STARTDATE_INPUT: 'timedcommand-startdate-input',
+  TIMEDCOMMAND_TABLE: 'timedcommand-table',
 } as const;
 
 export type TestId = (typeof TEST_IDS)[keyof typeof TEST_IDS];

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -29,8 +29,10 @@ const TimeCommandInput = ({ onReload }: Props) => {
   const [target, setTarget] = useState<string | undefined>();
   const [action, setAction] = useState<number>(0);
   const [value, setValue] = useState<number>(1);
-  const [startTime, setStartTime] = useState<dayjs.ConfigType>(
-    formatDateTime(dayjs().utc().format(DEFAULT_FORMAT_DATE_TIME))
+  // DatePicker's onChange will set YMD, but leave Hms.
+  // We could set them all to 0, but they do not matter in "serialization" in addField
+  const [startTime, setStartTime] = useState<dayjs.Dayjs>(
+    dayjs()
   );
   const [options, setOptions] = useState<{ users: SelectOptionsType; groups: SelectOptionsType }>({
     users: [],
@@ -47,7 +49,10 @@ const TimeCommandInput = ({ onReload }: Props) => {
       command: '',
       target_id: target,
       parameters: value,
-      date_start: dayjs(startTime).utc().format(DEFAULT_FORMAT_DATE_TIME),
+      // this will correctly, timezone-awarely get YMD, even for near-midnight values, ex.:
+      // good: dayjs('2025-04-22T00:01:00').format(DEFAULT_FORMAT_DATE_ONLY) == "2025-04-22"
+      // bad:  dayjs('2025-04-22T00:01:00').utc().format(DEFAULT_FORMAT_DATE_ONLY) == "2025-04-21"
+      date_start: startTime.format(DEFAULT_FORMAT_DATE_ONLY),
     });
     if (!response.error) onReload();
   }
@@ -186,12 +191,12 @@ const TimeCommandInput = ({ onReload }: Props) => {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker
             label={t(`settings.time.startDate`)}
-            value={dayjs(startTime)}
+            value={startTime}
             disabled={typeof action !== 'number'}
             format={DATE_FORMATS[i18next.language as LanguageTypes].dateOnly}
             minDate={minDate}
             onChange={(date) => {
-              if (date) setStartTime(dayjs(date).format(DEFAULT_FORMAT_DATE_TIME));
+              if (date) setStartTime(date)
             }}
             slotProps={{ textField: { size: 'small' } }}
           />

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -25,22 +25,21 @@ const TimeCommandInput = ({ onReload }: Props) => {
   const { t } = useTranslation();
   const { formatDateTime } = useDateFormatters();
 
+  // must not set commands in the past; use (client's) now / today
+  // since actions run on midnight, today's actions would never run, so minDate must be tomorrow
+  const minDate = dayjs().add(1, 'day')
+
   const [scope, setScope] = useState<number>(0);
   const [target, setTarget] = useState<string | undefined>();
   const [action, setAction] = useState<number>(0);
   const [value, setValue] = useState<number>(1);
   // DatePicker's onChange will set YMD, but leave Hms.
   // We could set them all to 0, but they do not matter in "serialization" in addField
-  const [startTime, setStartTime] = useState<dayjs.Dayjs>(
-    dayjs()
-  );
+  const [startTime, setStartTime] = useState<dayjs.Dayjs>(minDate);
   const [options, setOptions] = useState<{ users: SelectOptionsType; groups: SelectOptionsType }>({
     users: [],
     groups: [],
   });
-
-  // must not set commands in the past; use (client's) now / today
-  const minDate = dayjs()
 
   async function addField() {
     if (typeof action === 'undefined' || typeof scope === 'undefined' || typeof startTime === 'undefined') return;

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -5,7 +5,7 @@ import { getUsers } from '@/services/users';
 import { SelectOptionsType } from '@/types/SettingsTypes';
 import { LanguageTypes } from '@/types/Translation';
 import { Commands } from '@/utils/commands';
-import { DATE_FORMATS, DEFAULT_FORMAT_DATE_TIME } from '@/utils/units';
+import { DATE_FORMATS, DEFAULT_FORMAT_DATE_ONLY, DEFAULT_FORMAT_DATE_TIME } from '@/utils/units';
 import { Button, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -36,6 +36,9 @@ const TimeCommandInput = ({ onReload }: Props) => {
     users: [],
     groups: [],
   });
+
+  // must not set commands in the past; use (client's) now / today
+  const minDate = dayjs()
 
   async function addField() {
     if (typeof action === 'undefined' || typeof scope === 'undefined' || typeof startTime === 'undefined') return;
@@ -186,6 +189,7 @@ const TimeCommandInput = ({ onReload }: Props) => {
             value={dayjs(startTime)}
             disabled={typeof action !== 'number'}
             format={DATE_FORMATS[i18next.language as LanguageTypes].dateOnly}
+            minDate={minDate}
             onChange={(date) => {
               if (date) setStartTime(dayjs(date).format(DEFAULT_FORMAT_DATE_TIME));
             }}

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -26,8 +26,9 @@ const TimeCommandInput = ({ onReload }: Props) => {
   const { formatDateTime } = useDateFormatters();
 
   // must not set commands in the past; use (client's) now / today
-  // since actions run on midnight, today's actions would never run, so minDate must be tomorrow
-  const minDate = dayjs().add(1, 'day')
+  // (actions are scheduled midnight; an action scheduled for "today's midnight",
+  // which is technically in the past, will run immediately)
+  const minDate = dayjs()
 
   const [scope, setScope] = useState<number>(0);
   const [target, setTarget] = useState<string | undefined>();

--- a/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommandInput.tsx
@@ -2,6 +2,7 @@ import { useDateFormatters } from '@/hooks';
 import { addCommand } from '@/services/config';
 import { getGroups } from '@/services/groups';
 import { getUsers } from '@/services/users';
+import { TEST_IDS } from '@/test-ids';
 import { SelectOptionsType } from '@/types/SettingsTypes';
 import { LanguageTypes } from '@/types/Translation';
 import { Commands } from '@/utils/commands';
@@ -189,12 +190,14 @@ const TimeCommandInput = ({ onReload }: Props) => {
           </TextField>
         )}
         <LocalizationProvider dateAdapter={AdapterDayjs}>
+          {/* DatePicker does not support data-testid */}
           <DatePicker
             label={t(`settings.time.startDate`)}
             value={startTime}
             disabled={typeof action !== 'number'}
             format={DATE_FORMATS[i18next.language as LanguageTypes].dateOnly}
             minDate={minDate}
+            name={TEST_IDS.TIMEDCOMMAND_STARTDATE_INPUT}
             onChange={(date) => {
               if (date) setStartTime(date)
             }}
@@ -206,6 +209,7 @@ const TimeCommandInput = ({ onReload }: Props) => {
           onClick={addField}
           sx={{ py: 0.9, alignSelf: 'start' }}
           aria-label={t('actions.confirm')}
+          data-testid={TEST_IDS.TIMEDCOMMAND_CONFIRM_BUTTON}
         >
           {t('actions.confirm')}
         </Button>

--- a/src/views/Settings/Config/TimedCommands/TimedCommands.tsx
+++ b/src/views/Settings/Config/TimedCommands/TimedCommands.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { TEST_IDS } from '@/test-ids';
 import TimedCommandInput from './TimedCommandInput';
 
 const LIST_LIMIT = 10;
@@ -75,7 +76,10 @@ const TimedCommands = () => {
         <Stack>
           <Typography variant="h3">{t('settings.time.actions')}</Typography>
           <TableContainer>
-            <Table aria-label={t('ui.accessibility.scheduledActionsTable')}>
+            <Table
+              aria-label={t('ui.accessibility.scheduledActionsTable')}
+              data-testid={TEST_IDS.TIMEDCOMMAND_TABLE}
+            >
               <TableBody>
                 {commands.map((command, i) => {
                   const scope = command.cmd_id > 9 ? Math.floor(command.cmd_id / 10) : 0;

--- a/tests/lifecycle/cleanup.ts
+++ b/tests/lifecycle/cleanup.ts
@@ -78,6 +78,18 @@ export const CLEANUP_CONFIGS: CleanupConfig[] = [
     nameField: 'username',
     args: undefined,
   },
+  {
+    service: 'config',
+    method: 'getCommands',
+    deleteMethod: 'deleteCommand',
+    // TODO, this will delete *all* of them, we can't reasonably prefix anything...
+    filterField: 'date_start',
+    filterPrefix: '',
+    idField: 'id',
+    // not ideal
+    nameField: 'date_start',
+    args: undefined,
+  },
 ];
 
 export async function cleanupAllTestData(page: Page): Promise<void> {

--- a/tests/specs/core/admin-action.spec.ts
+++ b/tests/specs/core/admin-action.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/test-fixtures';
+import * as formInteractions from '../../interactions/forms';
+import * as navigation from '../../interactions/navigation';
+import { TEST_IDS } from '../../../src/test-ids';
+
+test.describe.serial('Admin configuration', () => {
+  test('Admin configures actions', async ({ adminPage }) => {
+    await test.step('Navigate to action settings', async () => {
+      await navigation.goToSettings(adminPage);
+      await navigation.openAccordion(adminPage, 'config-accordion-action');
+    });
+    // MUI DatePicker does not support data-testid
+    const startDateInput = adminPage.locator(`[name="${TEST_IDS.TIMEDCOMMAND_STARTDATE_INPUT}"]`)
+    const pastDate = '01.01.2000';
+    await test.step('Test past date invalid', async () => {
+      // MUI date inputs are hard to fill naively programmatically, but `fill` works.
+      // Default language is DE and MUI expects a localized string.
+      await startDateInput.fill(pastDate);
+      await expect(startDateInput).toHaveAttribute('aria-invalid', 'true');
+    });
+    // We could test with the default preset date = today, but an action scheduled for today
+    // at 00:00 is in effectively in the past and might execute immediately, or within seconds,
+    // and already not present when we GET the list in a subsequent fetch.
+    // So we pick a date that is definitely in the future; the easiest way to get the proper formatting
+    // is to set it one year in the future.
+    const futureYear = (new Date()).getFullYear() + 1
+    const futureDate = `01.01.${futureYear}`
+    const futureDateFormattedInTable = `${futureYear}-01-01 00:00:00`
+    await test.step('Test future action creation', async () => {
+      await startDateInput.fill(futureDate);
+      await expect(startDateInput).toHaveAttribute('aria-invalid', 'false');
+      await formInteractions.clickButton(adminPage, TEST_IDS.TIMEDCOMMAND_CONFIRM_BUTTON);
+      const timedactionTable = adminPage.getByTestId(TEST_IDS.TIMEDCOMMAND_TABLE);
+      await expect(timedactionTable).toBeVisible();
+      await expect(timedactionTable.getByRole('cell', { name: futureDateFormattedInTable })).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
by having minDate=today on the date picker

🤖 Resolves #926 <!-- issue # -->

## 👋 Intro
<!-- Describe what this PR is solving. -->

see title

## 🕵️ Context

<!-- Add any additional details that could assist with reviewing or testing this PR. -->

IMO there is more to do, due to timezones.

E.g.

- input in frontend: 1.6.2026
- because I am +2 this is submitted as 2026-05-31 22:00:00
- and because of the "auto set date to midnight" this ends up as 2026-05-31 00:00:00, so "even more yesterday"...

To solve this, I'd suggest not using date, but always using date+time

- I think this is usually better ux: actions - if i understand correctly - can start and end periods (e.g. Ferien). Usually the end date would be inclusive, which I think would not be the case as-is. Forcing users to acknowledge midnight avoids these errors. Some people also like to set 23:59:59 to be explicit. We could also add help text, maybe with an example.
- Still, the date input value would need to be made "timezoneless" (or inversely, the backend timezone-aware)

## 📋 Checklist

<!-- If any of the items is deliberately skipped, fill in the checkbox with `/` or `-` and include explanation for why -->
- [x] Tested manually
- [ ] Added e2e tests for new functionality
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->

n/a