### PR TITLE
FIx: revert typography changes affecting layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+## 1.9.1
 
+  - **Bug fixes**
+    - Fix letter spacing
+  
 ## 1.9.0
 
 - **New features**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aula",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "aula: gemeinsam gestalten",
   "author": {
     "name": "Aula App",

--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -19,7 +19,7 @@ const UserInfo = () => {
     getUserInfo();
   }, []);
   return (
-    <div className="m-2">
+    <div className="mx-2">
       {user && (
         <div className="flex flex-row items-center min-h-fit gap-2">
           <UserAvatar id={user.hash_id} size={52} />

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@ body {
 }
 
 p {
-  margin-bottom: 2em;
+  margin-bottom: 1em;
 }
 
 /* WCAG 1.4.12: Ensure containers expand with content — no fixed heights on text wrappers */

--- a/src/index.css
+++ b/src/index.css
@@ -42,32 +42,16 @@ body {
   font-family: 'Vision', 'Tahoma', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  /* WCAG 1.4.12: Text Spacing — baseline for non-MUI elements */
-  line-height: 1.5;
-  letter-spacing: 0.12em;
-  word-spacing: 0.16em;
 }
 
-/* WCAG 1.4.12: Set spacing directly on p so unlayered CSS beats Tailwind's text-* utilities
-   (which live in @layer utilities and set line-height directly on the element) */
 p {
   margin-bottom: 2em;
-  line-height: 1.5;
-  letter-spacing: 0.12em;
-  word-spacing: 0.16em;
 }
 
 /* WCAG 1.4.12: Ensure containers expand with content — no fixed heights on text wrappers */
 /* Buttons, nav items, and form fields use min-height so text can grow with spacing overrides */
 button, [role="button"], a, label, [role="menuitem"], [role="option"] {
   min-height: unset;
-}
-
-/* WCAG 1.4.12: Browsers reset spacing on form elements (UA stylesheet) — restore explicitly */
-button, input, textarea, select {
-  line-height: 1.5;
-  letter-spacing: 0.12em;
-  word-spacing: 0.16em;
 }
 
 code {
@@ -96,8 +80,6 @@ h4 {
    their line-height at that point, so we re-assert spacing after all heading size rules */
 h1, h2, h3, h4, h5, h6 {
   line-height: 1.5;
-  letter-spacing: 0.12em;
-  word-spacing: 0.16em;
 }
 
 .app-code {

--- a/src/layout/PrivateLayout/SideBar/SideBar.tsx
+++ b/src/layout/PrivateLayout/SideBar/SideBar.tsx
@@ -102,7 +102,7 @@ const SideBar = ({ onClose }: SideBarProps = {}): JSX.Element => {
           tabIndex={0 === focusIndex ? 0 : -1}
           onKeyDown={(e) => handleKeyDown(e as any, 0)}
           ref={setItemRef(0, focusIndex)}
-          className="block mt-1 py-1 rounded-lg transition-colors hover:bg-theme-grey"
+          className="block rounded-lg transition-colors hover:bg-theme-grey"
         >
           {isAuthenticated && <UserInfo />}
         </RippleLink>

--- a/src/theme/AppThemeProvider.tsx
+++ b/src/theme/AppThemeProvider.tsx
@@ -115,9 +115,7 @@ const AppThemeProvider: FunctionComponent<Props> = ({ children, emotionCache = C
           },
         },
       },
-      // WCAG 1.4.12: MuiChip uses a fixed `height` (32px / 24px) which clips text
-      // when letter-spacing or line-height are overridden. Switch to minHeight so
-      // the chip expands rather than truncating its label.
+
       MuiChip: {
         styleOverrides: {
           root: {
@@ -128,7 +126,6 @@ const AppThemeProvider: FunctionComponent<Props> = ({ children, emotionCache = C
             minHeight: 24,
           },
           label: {
-            // Allow label to wrap if word-spacing/letter-spacing pushes it wider
             whiteSpace: 'normal',
             paddingTop: 4,
             paddingBottom: 4,
@@ -136,24 +133,6 @@ const AppThemeProvider: FunctionComponent<Props> = ({ children, emotionCache = C
           labelSmall: {
             paddingTop: 2,
             paddingBottom: 2,
-          },
-        },
-      },
-      // WCAG 1.4.12: MUI hardcodes lineHeight: 1.4375em on FormLabel — override to meet minimum
-      MuiFormLabel: {
-        styleOverrides: {
-          root: {
-            lineHeight: 1.5,
-          },
-        },
-      },
-      // WCAG 1.4.12: MUI hardcodes lineHeight: 1.4375em on InputBase input; browsers also reset
-      // word-spacing on form elements so it must be explicitly set here
-      MuiInputBase: {
-        styleOverrides: {
-          input: {
-            lineHeight: 1.5,
-            wordSpacing: '0.16em',
           },
         },
       },

--- a/src/theme/fonts.ts
+++ b/src/theme/fonts.ts
@@ -7,10 +7,6 @@ const THEME_FONTS: ThemeOptions = {
   typography: {
     allVariants: {
       fontFamily: 'Vision',
-      // WCAG 1.4.12: Text Spacing — minimum values so containers never clip text
-      lineHeight: 1.5,       // ≥ 1.5× font size
-      letterSpacing: '0.12em', // ≥ 0.12× font size
-      wordSpacing: '0.16em',   // ≥ 0.16× font size
     },
     body1: {
       fontFamily: 'Vision',


### PR DESCRIPTION
## 👋 Intro

Letter spacing was wrongly changed on WCAG compliance updates

## 📋 Checklist

<!-- If any of the items is deliberately skipped, fill in the checkbox with `/` or `-` and include explanation for why -->
- [x] Tested manually
- [ ] Added e2e tests for new functionality
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
