### PR TITLE
fix: fab buttons misplaced

### DIFF
--- a/src/views/BoxPhase/BoxPhaseView.tsx
+++ b/src/views/BoxPhase/BoxPhaseView.tsx
@@ -153,12 +153,16 @@ const BoxPhaseView = () => {
         sx={{
           position: 'fixed',
           bottom: 'max(40px, calc(40px + var(--safe-area-inset-bottom, 0px)))',
-          right: 16,
           zIndex: 1000,
         }}
       >
         {checkPermissions('boxes', 'create') && Number(phase) === 10 && (
-          <Fab aria-label={t('ui.accessibility.addIdea')} color="primary" onClick={() => setEdit(true)} data-testid="add-idea-button">
+          <Fab
+            aria-label={t('ui.accessibility.addIdea')}
+            color="primary"
+            onClick={() => setEdit(true)}
+            data-testid="add-idea-button"
+          >
             <AppIcon icon="box" />
           </Fab>
         )}

--- a/src/views/WildIdeas/WildIdeasView.tsx
+++ b/src/views/WildIdeas/WildIdeasView.tsx
@@ -179,7 +179,6 @@ const WildIdeas = () => {
           sx={{
             position: 'fixed',
             bottom: 'max(40px, calc(40px + var(--safe-area-inset-bottom, 0px)))',
-            right: 16,
             zIndex: 1000,
           }}
           data-testid="add-idea-button"


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Intro

FAB buttons where misplaced

## 🕵️ Context

## 📋 Checklist

<!-- If any of the items is deliberately skipped, fill in the checkbox with `/` or `-` and include explanation for why -->
- [x] Tested manually
- [ ] Added e2e tests for new functionality
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
