### PR TITLE
A11y/login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+
+- **Internal**
+  - Completed v2 component migration for public routes (Login, Recovery, Code, NotFound)
+  - v2 private layout components (PrivateLayout, TopBar, SideBar) now fully migrated
+
+
 ## 1.9.2
 
   - **Bug fixes**

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,3 +1,4 @@
+import PopupMessages from '@/components/PopupMessages';
 import { useConsentSync, useIsAuthenticated } from '@/hooks/auth';
 import Private from '@/v2/views/private';
 import Public from '@/v2/views/public';
@@ -12,6 +13,13 @@ const Routes = () => {
 
   useConsentSync(isAuthenticated, location.pathname);
 
-  return isAuthenticated ? <Private /> : <Public />;
+  const autentication = () => (isAuthenticated ? <Private /> : <Public />);
+
+  return (
+    <>
+      {autentication()}
+      <PopupMessages />
+    </>
+  );
 };
 export default Routes;

--- a/src/v2/components/button/Code/CodeButton.tsx
+++ b/src/v2/components/button/Code/CodeButton.tsx
@@ -12,7 +12,7 @@ const CodeButton = () => {
 
   if (!code) {
     return (
-      <Chip role="status" aria-label={t('auth.login.reset_code')} data-testid="current-instance-code">
+      <Chip role="status" aria-label={t('auth.login.reset_code')} data-testid="no-instance-code">
         {t('auth.login.reset_code')}
       </Chip>
     );

--- a/src/v2/components/button/Code/CodeButton.tsx
+++ b/src/v2/components/button/Code/CodeButton.tsx
@@ -12,7 +12,7 @@ const CodeButton = () => {
 
   if (!code) {
     return (
-      <Chip role="status" aria-label={t('auth.login.reset_code')}>
+      <Chip role="status" aria-label={t('auth.login.reset_code')} data-testid="current-instance-code">
         {t('auth.login.reset_code')}
       </Chip>
     );

--- a/src/v2/views/public/Code/InstanceCodeView.tsx
+++ b/src/v2/views/public/Code/InstanceCodeView.tsx
@@ -19,8 +19,8 @@ const InstanceCodeView = () => {
         instanceCode: yup
           .string()
           .required(t('forms.validation.required'))
-          .min(MIN_CODE_LENGTH, t('forms.validation.min', { min: MIN_CODE_LENGTH }))
-          .max(MAX_CODE_LENGTH, t('forms.validation.max', { max: MAX_CODE_LENGTH })),
+          .min(MIN_CODE_LENGTH, t('forms.validation.minLength', { var: MIN_CODE_LENGTH }))
+          .max(MAX_CODE_LENGTH, t('forms.validation.maxLength', { var: MAX_CODE_LENGTH })),
       }),
     [t]
   );

--- a/tests/interactions/users.ts
+++ b/tests/interactions/users.ts
@@ -95,8 +95,8 @@ export const ensureInstanceEntered = async (page: Page, username?: string) => {
   }
 
   const instance = process.env.INSTANCE_CODE || 'SINGLE';
-  const instanceCodeInputDiv = page.getByTestId('input-instance-code');
-  if ((await instanceCodeInputDiv.count()) === 0) {
+  const instanceCodeInput = page.locator('input[name="instanceCode"]');
+  if ((await instanceCodeInput.count()) === 0) {
     console.log(`${instance === 'SINGLE' ? '✅' : '⚠️'} No instance selector input found. User: "${username}"`);
     if (instance !== 'SINGLE') {
       throw new Error('Instance selector input not found on the page, but we are testing a multi-instance FE.');
@@ -106,8 +106,8 @@ export const ensureInstanceEntered = async (page: Page, username?: string) => {
     return true;
   } else {
     console.log(`ℹ️ Testing multi instance FE, attempting to use "${instance}"... User: "${username}"`);
-    await instanceCodeInputDiv.locator(page.locator('input[name="instance-code"]')).fill(instance);
-    await page.getByTestId('submit-instance-code').click();
+    await instanceCodeInput.fill(instance);
+    await page.locator('button[type="submit"]').click();
     await page.waitForURL((url) => url.pathname === '/', { waitUntil: 'domcontentloaded' });
     return true;
   }

--- a/tests/specs/core/login.spec.ts
+++ b/tests/specs/core/login.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import * as shared from '../../support/utils';
+
+const host = shared.getHost();
+const INSTANCE_CODE = process.env.INSTANCE_CODE;
+const IS_MULTI = !!INSTANCE_CODE && INSTANCE_CODE !== 'SINGLE';
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'aula';
+
+/**
+ * Login flow tests
+ *
+ * Covers instance code entry (multi-instance only) and login form validation.
+ * Each test gets a fresh, unauthenticated browser context — no fixtures needed.
+ *
+ * Tests run serially because they follow a sequential user journey:
+ * enter code → verify error → enter correct code → login error → login success
+ */
+
+test.describe.serial('Instance code entry', () => {
+  test.skip(!IS_MULTI, 'Single-instance setup — skipping instance code tests');
+
+  test('submitting a wrong instance code shows an error message', async ({ page }) => {
+    await page.goto(`${host}/code`, { waitUntil: 'domcontentloaded' });
+
+    await page.fill('input[name="instanceCode"]', 'WRONG_CODE_XYZ');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.getByRole('alert')).toBeVisible();
+  });
+
+  test('submitting the correct instance code proceeds to the login form', async ({ page }) => {
+    await page.goto(`${host}/code`, { waitUntil: 'domcontentloaded' });
+
+    await page.fill('input[name="instanceCode"]', INSTANCE_CODE!);
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('input[name="username"]')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('clicking the instance code chip clears the code and returns to /code', async ({ page }) => {
+    // Enter the code first so the dismissible chip (with onClick) is rendered instead of the passive status chip.
+    await page.goto(`${host}/code`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('input[name="instanceCode"]')).toBeVisible();
+    await page.fill('input[name="instanceCode"]', INSTANCE_CODE!);
+    await page.locator('button[type="submit"]').click();
+    await page.waitForURL((url) => url.pathname === '/', { waitUntil: 'domcontentloaded' });
+
+    const chip = page.getByTestId('current-instance-code');
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    await expect(page).toHaveURL(/\/code/);
+    await expect(page.locator('input[name="instanceCode"]')).toBeVisible();
+  });
+});
+
+test.describe.serial('Login form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(host, { waitUntil: 'domcontentloaded' });
+
+    if (IS_MULTI) {
+      // Go through the code form so that validateAndSaveInstanceCode runs and sets api_url in localStorage.
+      // Setting 'code' directly via localStorage is insufficient — the new login flow also requires api_url.
+      await page.goto(`${host}/code`, { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('input[name="instanceCode"]')).toBeVisible();
+      await page.fill('input[name="instanceCode"]', INSTANCE_CODE!);
+      await page.locator('button[type="submit"]').click();
+      await page.waitForURL((url) => url.pathname === '/', { waitUntil: 'domcontentloaded' });
+    }
+
+    await expect(page.locator('input[name="username"]')).toBeVisible();
+  });
+
+  test('submitting wrong credentials shows an error message', async ({ page }) => {
+    await page.goto(host, { waitUntil: 'domcontentloaded' });
+
+    await page.fill('input[name="username"]', 'wrong_user_xyz');
+    await page.fill('input[name="password"]', 'wrong_password');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.getByTestId('error-alert')).toBeVisible();
+  });
+
+  test('submitting correct credentials logs the user in', async ({ page }) => {
+    await page.fill('input[name="username"]', ADMIN_USERNAME);
+    await page.fill('input[name="password"]', ADMIN_PASSWORD);
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('#rooms-heading')).toBeVisible({ timeout: 20000 });
+  });
+});


### PR DESCRIPTION
🤖 Resolves <!-- issue # -->

## 👋 Intro

Case study for the migrations to Tailwind and review of accessibility.

**This is a PR for the main migration branch**

## 🕵️ Context

**Why this migration?**

The old login flow mixed business logic, API calls, config loading, state management, and UI rendering all inside a single component. The new v2 approach separates concerns cleanly, in a more organized way. This enforces maintainability and helps to prepare for the migration to v2 BE.

**Why migrate away from MUI components?**

MUI form fields, like the TextField, required manually wiring aria-labelledby, aria-errormessage, id, htmlFor, slotProps.input, slotProps.htmlInput, and slotProps.inputLabel in every single usage to get accessible markup. The new components, as the [TextInput](https://github.com/aula-app/aula-frontend/blob/a11y/review/src/v2/components/input/TextInput.tsx) bakes all of that in: it auto-generates ids via useId(), links labels and error messages via aria-describedby, and handles the password toggle internally. Callers pass label, error, and {...register(...)}.

**What about tests?**

MUI's form components doesn't render a straightforward <input> — it wraps it in multiple div layers, and for Select the underlying native input is marked aria-hidden="true", making it invisible to Playwright's standard locators. To work around this, the test suite had to implement custom helpers that inspect whether an input is real or aria-hidden before deciding how to interact with it (see [forms.ts:34–48](https://github.com/aula-app/aula-frontend/tree/main/tests/interactions/forms.ts#L34-L48)).

With native <input> elements, none of that is needed. Playwright's built-in locators work directly against the actual DOM — as seen in [users.ts:119–122](https://github.com/aula-app/aula-frontend/tree/main/tests/interactions/users.ts#L119-L122). Because TextInput renders a real <input> with a proper <label> wired via htmlFor/useId(), tests can also use semantic locators like page.getByLabel('Username') — no test IDs, no workarounds, no branching logic.

## 📋 Checklist

<!-- If any of the items is deliberately skipped, fill in the checkbox with `/` or `-` and include explanation for why -->
- [x] Tested manually
- [x] Added e2e tests for new functionality
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [ ] Backward and forward compatible with [aula-backend/releases](https://github.com/aula-app/aula-backend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database or BE <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->

## 📸 Screenshot

<!-- Add a screenshot (if possible). -->
